### PR TITLE
Fix V3025

### DIFF
--- a/src/TQVaultAE.DAL/ArzFile.cs
+++ b/src/TQVaultAE.DAL/ArzFile.cs
@@ -478,8 +478,8 @@ namespace TQVaultData
 							}
 
 							TQDebug.DebugWriteLine(string.Format(CultureInfo.InvariantCulture, "Error in ARZFile - {0}", arzFile.fileName));
-							TQDebug.DebugWriteLine(string.Format(CultureInfo.InvariantCulture, "Error while parsing arz record {0}, variable {2}, bad dataType {3}", this.ID, variableName, dataType));
-							throw new ArgumentOutOfRangeException(string.Format(CultureInfo.InvariantCulture, "Error while parsing arz record {0}, variable {2}, bad dataType {3}", this.ID, variableName, dataType));
+							TQDebug.DebugWriteLine(string.Format(CultureInfo.InvariantCulture, "Error while parsing arz record {0}, variable {1}, bad dataType {2}", this.ID, variableName, dataType));
+							throw new ArgumentOutOfRangeException(string.Format(CultureInfo.InvariantCulture, "Error while parsing arz record {0}, variable {1}, bad dataType {2}", this.ID, variableName, dataType));
 						}
 
 						Variable v = new Variable(variableName, (VariableDataType)dataType, valCount);


### PR DESCRIPTION
Hello! I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio:

- Incorrect format. A different number of format items is expected while calling 'Format' function. Format items not used: {3}. Arguments not used: 3rd. TQVaultAE.DAL ArzFile.cs 481

- Incorrect format. A different number of format items is expected while calling 'Format' function. Format items not used: {3}. Arguments not used: 3rd. TQVaultAE.DAL ArzFile.cs 482