### PR TITLE
Add support for ranged weapons

### DIFF
--- a/src/TQVaultAE.DAL/Item.cs
+++ b/src/TQVaultAE.DAL/Item.cs
@@ -3232,6 +3232,9 @@ namespace TQVaultData
 				case "WEAPONHUNTING_SPEAR":
 					return "spear";
 
+ 				case "WEAPONHUNTING_RANGEDONEHAND":
+ 					return "bow";
+
 				case "WEAPONMELEE_AXE":
 					return "axe";
 


### PR DESCRIPTION
The new Ranged weapons from Ragnarok uses the "bow" prefix for requirements.
