### PR TITLE
Clone Variable to avoid referenced value change

### DIFF
--- a/src/TQVaultAE.DAL/Item.cs
+++ b/src/TQVaultAE.DAL/Item.cs
@@ -5667,10 +5667,15 @@ namespace TQVaultData
 				color = labelColor;
 			}
 
-			Variable currentVariable = minVar;
-			if (currentVariable == null)
+			Variable currentVariable = null;
+
+			if (minVar != null)
 			{
-				currentVariable = maxVar;
+				currentVariable = minVar.clone();
+			}
+			else if(maxVar!=null)
+			{
+				currentVariable = maxVar.clone();
 			}
 
 			if (currentVariable != null)
@@ -5715,6 +5720,17 @@ namespace TQVaultData
 			// Added by VillageIdiot : check to see if min and max are the same
 			string color = null;
 			string amount = null;
+
+			Variable min = null;
+			Variable max = null;
+			if(minVar!=null)
+			{
+				min = minVar.clone();
+			}
+			if (maxVar != null)
+			{
+				max = maxVar.clone();
+			}
 
 			// sweet we have a range
 			string tag = "DamageRangeFormat";
@@ -5762,16 +5778,16 @@ namespace TQVaultData
 			// Adjust for itemScalePercent
 			if (minDurVar != null)
 			{
-				minVar[Math.Min(minVar.NumberOfValues - 1, varNum)] = (float)minVar[Math.Min(minVar.NumberOfValues - 1, varNum)] * (float)minDurVar[minDurVar.NumberOfValues - 1] * this.itemScalePercent;
-				maxVar[Math.Min(maxVar.NumberOfValues - 1, varNum)] = (float)maxVar[Math.Min(maxVar.NumberOfValues - 1, varNum)] * (float)minDurVar[minDurVar.NumberOfValues - 1] * this.itemScalePercent;
+				min[Math.Min(min.NumberOfValues - 1, varNum)] = (float)min[Math.Min(min.NumberOfValues - 1, varNum)] * (float)minDurVar[minDurVar.NumberOfValues - 1] * this.itemScalePercent;
+				max[Math.Min(max.NumberOfValues - 1, varNum)] = (float)max[Math.Min(max.NumberOfValues - 1, varNum)] * (float)minDurVar[minDurVar.NumberOfValues - 1] * this.itemScalePercent;
 			}
 			else
 			{
-				minVar[Math.Min(minVar.NumberOfValues - 1, varNum)] = (float)minVar[Math.Min(minVar.NumberOfValues - 1, varNum)] * this.itemScalePercent;
-				maxVar[Math.Min(maxVar.NumberOfValues - 1, varNum)] = (float)maxVar[Math.Min(maxVar.NumberOfValues - 1, varNum)] * this.itemScalePercent;
+				min[Math.Min(min.NumberOfValues - 1, varNum)] = (float)min[Math.Min(min.NumberOfValues - 1, varNum)] * this.itemScalePercent;
+				max[Math.Min(max.NumberOfValues - 1, varNum)] = (float)max[Math.Min(max.NumberOfValues - 1, varNum)] * this.itemScalePercent;
 			}
 
-			amount = Item.Format(formatSpec, minVar[Math.Min(minVar.NumberOfValues - 1, varNum)], maxVar[Math.Min(maxVar.NumberOfValues - 1, varNum)]);
+			amount = Item.Format(formatSpec, min[Math.Min(min.NumberOfValues - 1, varNum)], max[Math.Min(max.NumberOfValues - 1, varNum)]);
 			amount = Database.MakeSafeForHtml(amount);
 			if (!string.IsNullOrEmpty(color))
 			{

--- a/src/TQVaultAE.DAL/Variable.cs
+++ b/src/TQVaultAE.DAL/Variable.cs
@@ -73,6 +73,13 @@ namespace TQVaultData
 		/// </summary>
 		public string Name { get; private set; }
 
+		public Variable clone()
+		{
+			Variable newVariable = (Variable) this.MemberwiseClone();
+			newVariable.values = (object []) this.values.Clone();
+			return newVariable;
+		}
+
 		/// <summary>
 		/// Gets the Datatype of the variable.
 		/// </summary>


### PR DESCRIPTION
When the same item is present multiple times in the same sack, an
attribute will use the same Variable object (and values). The
reference to the Variable object is passed to methods that does
calculation and put the result back, leaving the new value to the
next item in the sack, making an attribute value to be calculated
multiple times and showing wrong numbers. With this change, the
Variable and it's values are cloned. Since the values are primitives,
the Array.clone() is sufficient to do the needed deep copy of the
values.