### PR TITLE
Refactor cheats

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,12 +144,12 @@ TQVaultAE only displays the base stats (and not the modifications due to the RNG
 
 *A. Yes*
 
-**Q. How to activate TQVaultAE "edition features"? (character edit, copy item, edit item)**
+**Q. How to activate the cheats (character edit, copy item, edit item)?**
 
 *A. Follow these steps:*
 1. *Navigate the the installation folder of TQVaultAE*
 2. *Open `TQVaultAE.exe.config` in a text editor (i.e. notepad, **not Microsoft Word**)*
-3. *Find the key `ShowEditingCopyFeatures` and change the value from `False` to `True`*
+3. *Find the key `AllowCheats` and change the value from `False` to `True`*
 
 **Q. I have a problem not listed here. What can I do?**
 

--- a/src/TQVaultAE.Config/App.config
+++ b/src/TQVaultAE.Config/App.config
@@ -116,7 +116,7 @@
       <setting name="AllowCharacterEdit" serializeAs="String">
         <value>False</value>
       </setting>
-      <setting name="ShowEditingCopyFeatures" serializeAs="String">
+      <setting name="AllowCheats" serializeAs="String">
         <value>False</value>
       </setting>
       <setting name="ForceGamePath" serializeAs="String">

--- a/src/TQVaultAE.Config/Settings.Designer.cs
+++ b/src/TQVaultAE.Config/Settings.Designer.cs
@@ -398,12 +398,13 @@ namespace TQVaultAE.Config {
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("False")]
-        public bool ShowEditingCopyFeatures {
+        public bool AllowCheats
+		{
             get {
-                return ((bool)(this["ShowEditingCopyFeatures"]));
+                return ((bool)(this["AllowCheats"]));
             }
             set {
-                this["ShowEditingCopyFeatures"] = value;
+                this["AllowCheats"] = value;
             }
         }
         

--- a/src/TQVaultAE.Config/Settings.settings
+++ b/src/TQVaultAE.Config/Settings.settings
@@ -104,7 +104,7 @@
     <Setting Name="AllowCharacterEdit" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
-    <Setting Name="ShowEditingCopyFeatures" Type="System.Boolean" Scope="User">
+    <Setting Name="AllowCheats" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
     <Setting Name="ForceGamePath" Type="System.String" Scope="User">

--- a/src/TQVaultAE.GUI/CharacterEditDialog.Designer.cs
+++ b/src/TQVaultAE.GUI/CharacterEditDialog.Designer.cs
@@ -54,7 +54,6 @@ namespace TQVaultAE.GUI
             this.healthLabel = new TQVaultAE.GUI.Components.ScalingLabel();
             this.manaLabel = new TQVaultAE.GUI.Components.ScalingLabel();
             this.attribGroupBox = new System.Windows.Forms.GroupBox();
-            this.redistrbuteCheckbox = new TQVaultAE.GUI.Components.ScalingCheckBox();
             this.manacUpDown = new System.Windows.Forms.NumericUpDown();
             this.healthUpDown = new System.Windows.Forms.NumericUpDown();
             this.intelligenceUpDown = new System.Windows.Forms.NumericUpDown();
@@ -186,7 +185,6 @@ namespace TQVaultAE.GUI
             // attribGroupBox
             // 
             this.attribGroupBox.BackColor = System.Drawing.Color.Transparent;
-            this.attribGroupBox.Controls.Add(this.redistrbuteCheckbox);
             this.attribGroupBox.Controls.Add(this.manacUpDown);
             this.attribGroupBox.Controls.Add(this.healthUpDown);
             this.attribGroupBox.Controls.Add(this.intelligenceUpDown);
@@ -205,19 +203,6 @@ namespace TQVaultAE.GUI
             this.attribGroupBox.TabStop = false;
             this.attribGroupBox.Text = "Base Attributes";
             this.attribGroupBox.Enter += new System.EventHandler(this.GroupBox1_Enter);
-            // 
-            // redistrbuteCheckbox
-            // 
-            this.redistrbuteCheckbox.AutoSize = true;
-            this.redistrbuteCheckbox.CheckAlign = System.Drawing.ContentAlignment.MiddleRight;
-            this.redistrbuteCheckbox.Font = new System.Drawing.Font("Microsoft Sans Serif", 11.25F);
-            this.redistrbuteCheckbox.Location = new System.Drawing.Point(25, 275);
-            this.redistrbuteCheckbox.Name = "redistrbuteCheckbox";
-            this.redistrbuteCheckbox.Size = new System.Drawing.Size(154, 22);
-            this.redistrbuteCheckbox.TabIndex = 6;
-            this.redistrbuteCheckbox.Text = "Enable Redistribute";
-            this.redistrbuteCheckbox.UseVisualStyleBackColor = true;
-            this.redistrbuteCheckbox.CheckedChanged += new System.EventHandler(this.RedistrbuteCheckbox_CheckedChanged);
             // 
             // manacUpDown
             // 
@@ -556,7 +541,6 @@ namespace TQVaultAE.GUI
             this.Controls.SetChildIndex(this.attribGroupBox, 0);
             this.Controls.SetChildIndex(this.levelingGroupBox, 0);
             this.attribGroupBox.ResumeLayout(false);
-            this.attribGroupBox.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.manacUpDown)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.healthUpDown)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.intelligenceUpDown)).EndInit();
@@ -593,7 +577,6 @@ namespace TQVaultAE.GUI
 		private ScalingLabel attributeLabel1;
 		private System.Windows.Forms.NumericUpDown skillPointsNumericUpDown;
 		private ScalingLabel skillPointsLabel1;
-		private ScalingCheckBox redistrbuteCheckbox;
 		private ScalingLabel difficultyLabel;
 		private System.Windows.Forms.ComboBox difficultlyComboBox;
 		private ScalingCheckBox levelingCheckBox;

--- a/src/TQVaultAE.GUI/CharacterEditDialog.cs
+++ b/src/TQVaultAE.GUI/CharacterEditDialog.cs
@@ -181,7 +181,6 @@ namespace TQVaultAE.GUI
 			attributeLabel1.Text = Resources.CEAttributePoints;
 			skillPointsLabel1.Text = Resources.CESkillPoints;
 			levelingCheckBox.Text = Resources.CEEnableLeveling;
-			redistrbuteCheckbox.Text = Resources.CEEnableRedistribute;
 			levelingGroupBox.Text = Resources.CELeveling;
 			attribGroupBox.Text = Resources.CEAttributes;
 			difficultyLabel.Text = Resources.CEDifficulty;
@@ -251,7 +250,6 @@ namespace TQVaultAE.GUI
 
 			setDifficultly();
 
-			redistrbuteCheckbox.Checked = true;
 			levelingCheckBox.Checked = false;
 
 			if (_playerCollection.PlayerInfo.HasBeenInGame == 0)
@@ -314,8 +312,6 @@ namespace TQVaultAE.GUI
 			var upDwnCtrl = (NumericUpDown)sender;
 			if (upDwnCtrl.Tag == null) return;
 
-			if (!redistrbuteCheckbox.Checked) return;
-
 			var prevValue = Convert.ToInt32(((UpDownBase)sender).Text);
 			var value = Convert.ToInt32(upDwnCtrl.Value);
 
@@ -337,22 +333,6 @@ namespace TQVaultAE.GUI
 
 		}
 
-		private void RedistrbuteCheckbox_CheckedChanged(object sender, EventArgs e)
-		{
-			if (sender == null) return;
-
-			var chkbx = (CheckBox)sender;
-			if (chkbx.Checked)
-			{
-
-			}
-			else
-			{
-
-			}
-
-		}
-
 		private void LevelingCheckBox_CheckedChanged(object sender, EventArgs e)
 		{
 			if (sender == null) return;
@@ -360,21 +340,12 @@ namespace TQVaultAE.GUI
 			var chkbx = (CheckBox)sender;
 			if (chkbx.Checked)
 			{
-				//this.manacUpDown 
-				//this.healthUpDown
-				//this.intelligenceUpDown 
-				//this.dexterityUpDown 
-				//this.strengthUpDown 
 				this.difficultlyComboBox.Enabled = true;
-				this.skillPointsNumericUpDown.Enabled = true;
-				this.attributeNumericUpDown.Enabled = true;
 				this.levelNumericUpDown.Enabled = true;
 			}
 			else
 			{
 				this.difficultlyComboBox.Enabled = false;
-				this.skillPointsNumericUpDown.Enabled = false;
-				this.attributeNumericUpDown.Enabled = false;
 				this.levelNumericUpDown.Enabled = false;
 			}
 

--- a/src/TQVaultAE.GUI/CharacterEditDialog.cs
+++ b/src/TQVaultAE.GUI/CharacterEditDialog.cs
@@ -130,6 +130,7 @@ namespace TQVaultAE.GUI
 		/// <param name="e">EventArgs data</param>
 		private void OKButton_Click(object sender, EventArgs e)
 		{
+			if (!Config.Settings.Default.AllowCharacterEdit) return;
 			if (_playerCollection.PlayerInfo == null) return;
 			try
 			{

--- a/src/TQVaultAE.GUI/CharacterEditDialog.resx
+++ b/src/TQVaultAE.GUI/CharacterEditDialog.resx
@@ -112,12 +112,12 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="ok.DownBitmap" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAAIkAAAAeCAYAAAAYRz0yAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO

--- a/src/TQVaultAE.GUI/MainForm.cs
+++ b/src/TQVaultAE.GUI/MainForm.cs
@@ -879,7 +879,7 @@ namespace TQVaultAE.GUI
 					TQData.MapName = Config.Settings.Default.Mod;
 				}
 
-				if (!Config.Settings.Default.ShowEditingCopyFeatures)
+				if (!Config.Settings.Default.AllowCheats)
 				{
 					Config.Settings.Default.AllowItemCopy = false;
 					Config.Settings.Default.AllowItemEdit = false;

--- a/src/TQVaultAE.GUI/MainForm.cs
+++ b/src/TQVaultAE.GUI/MainForm.cs
@@ -883,6 +883,7 @@ namespace TQVaultAE.GUI
 				{
 					Config.Settings.Default.AllowItemCopy = false;
 					Config.Settings.Default.AllowItemEdit = false;
+					Config.Settings.Default.AllowCharacterEdit = false;
 				}
 
 				CommandLineArgs args = new CommandLineArgs();

--- a/src/TQVaultAE.GUI/SettingsDialog.cs
+++ b/src/TQVaultAE.GUI/SettingsDialog.cs
@@ -228,7 +228,7 @@ namespace TQVaultAE.GUI
 			{
 				this.mapListComboBox.Items.AddRange(maps);
 			}
-			if (!Config.Settings.Default.ShowEditingCopyFeatures)
+			if (!Config.Settings.Default.AllowCheats)
 			{
 				this.allowItemEditCheckBox.Visible = false;
 				this.allowItemCopyCheckBox.Visible = false;

--- a/src/TQVaultAE.GUI/app.config
+++ b/src/TQVaultAE.GUI/app.config
@@ -76,7 +76,7 @@
       <setting name="AllowCharacterEdit" serializeAs="String">
         <value>False</value>
       </setting>
-      <setting name="ShowEditingCopyFeatures" serializeAs="String">
+      <setting name="AllowCheats" serializeAs="String">
         <value>False</value>
       </setting>
       <setting name="ForceGamePath" serializeAs="String">

--- a/src/TQVaultAE.Presentation/Resources.Designer.cs
+++ b/src/TQVaultAE.Presentation/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace TQVaultAE.Presentation {
     // à l'aide d'un outil, tel que ResGen ou Visual Studio.
     // Pour ajouter ou supprimer un membre, modifiez votre fichier .ResX, puis réexécutez ResGen
     // avec l'option /str ou régénérez votre projet VS.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {
@@ -620,15 +620,6 @@ namespace TQVaultAE.Presentation {
         public static string CEEnableLeveling {
             get {
                 return ResourceManager.GetString("CEEnableLeveling", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Recherche une chaîne localisée semblable à Enable Redistribute.
-        /// </summary>
-        public static string CEEnableRedistribute {
-            get {
-                return ResourceManager.GetString("CEEnableRedistribute", resourceCulture);
             }
         }
         

--- a/src/TQVaultAE.Presentation/Resources.de.resx
+++ b/src/TQVaultAE.Presentation/Resources.de.resx
@@ -112,10 +112,10 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AboutDescription" xml:space="preserve">
     <value>TQVault von bman654 (wickedsoul_@yahoo.com) 
@@ -992,7 +992,6 @@ Hier ist ein komplexes Beispiel: 'arctic &amp; frost @schwert $ episch | selten'
   <data name="GlobalRelicVaultStash" xml:space="preserve">
     <value>Reliktgewölbe</value>
   </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="SettingsAllowEditCE" xml:space="preserve">
     <value>Zeichenbearbeitungsfunktionen zulassen</value>
   </data>
@@ -1019,9 +1018,6 @@ Hier ist ein komplexes Beispiel: 'arctic &amp; frost @schwert $ episch | selten'
   </data>
   <data name="CEEnableLeveling" xml:space="preserve">
     <value>Leveling aktivieren</value>
-  </data>
-  <data name="CEEnableRedistribute" xml:space="preserve">
-    <value>Neuverteilung aktivieren</value>
   </data>
   <data name="CEHealth" xml:space="preserve">
     <value>Gesundheit</value>
@@ -1050,87 +1046,244 @@ Hier ist ein komplexes Beispiel: 'arctic &amp; frost @schwert $ episch | selten'
   <data name="CharacterEditBtn" xml:space="preserve">
     <value>Bearbeiten</value>
   </data>
-  
-  <data name="tagCClass01" xml:space="preserve"><value>Theurgist</value></data>
-  <data name="tagCClass02" xml:space="preserve"><value>Wanderer</value></data>
-  <data name="tagCClass03" xml:space="preserve"><value>Schurke</value></data>
-  <data name="tagCClass04" xml:space="preserve"><value>Jäger</value></data>
-  <data name="tagCClass05" xml:space="preserve"><value>Sturmrufer</value></data>
-  <data name="tagCClass06" xml:space="preserve"><value>Pyromant</value></data>
-  <data name="tagCClass07" xml:space="preserve"><value>Verteidiger</value></data>
-  <data name="tagCClass08" xml:space="preserve"><value>Krieger</value></data>
-  <data name="tagCClass09" xml:space="preserve"><value>Zauberbrecher</value></data>
-  <data name="tagCClass10" xml:space="preserve"><value>Champion</value></data>
-  <data name="tagCClass11" xml:space="preserve"><value>Attentäter</value></data>
-  <data name="tagCClass12" xml:space="preserve"><value>Jägerin</value></data>
-  <data name="tagCClass13" xml:space="preserve"><value>Thane</value></data>
-  <data name="tagCClass14" xml:space="preserve"><value>Kampfmagier</value></data>
-  <data name="tagCClass15" xml:space="preserve"><value>Eroberer</value></data>
-  <data name="tagCClass16" xml:space="preserve"><value>Zauberbinder</value></data>
-  <data name="tagCClass17" xml:space="preserve"><value>Wächter</value></data>
-  <data name="tagCClass18" xml:space="preserve"><value>Korsar</value></data>
-  <data name="tagCClass19" xml:space="preserve"><value>Aufseher</value></data>
-  <data name="tagCClass20" xml:space="preserve"><value>Paladin</value></data>
-  <data name="tagCClass21" xml:space="preserve"><value>Moloch</value></data>
-  <data name="tagCClass22" xml:space="preserve"><value>Zauberkünstler</value></data>
-  <data name="tagCClass23" xml:space="preserve"><value>Beschwörer</value></data>
-  <data name="tagCClass24" xml:space="preserve"><value>Zauberer</value></data>
-  <data name="tagCClass25" xml:space="preserve"><value>Rächer</value></data>
-  <data name="tagCClass26" xml:space="preserve"><value>Elementalist</value></data>
-  <data name="tagCClass27" xml:space="preserve"><value>Orakel</value></data>
-  <data name="tagCClass28" xml:space="preserve"><value>Druide</value></data>
-  <data name="tagCClass29" xml:space="preserve"><value>Zauberer</value></data>
-  <data name="tagCClass30" xml:space="preserve"><value>Salbei</value></data>
-  <data name="tagCClass31" xml:space="preserve"><value>Knochenbeschwörer</value></data>
-  <data name="tagCClass32" xml:space="preserve"><value>Ranger</value></data>
-  <data name="tagCClass33" xml:space="preserve"><value>Räuber</value></data>
-  <data name="tagCClass34" xml:space="preserve"><value>Hexenmeister</value></data>
-  <data name="tagCClass35" xml:space="preserve"><value>Illusionist</value></data>
-  <data name="tagCClass36" xml:space="preserve"><value>Wahrsager</value></data>
-  <data name="xtagCharacterClass01" xml:space="preserve"><value>Seher</value></data>
-  <data name="xtagCharacterClass02" xml:space="preserve"><value>Vorbote</value></data>
-  <data name="xtagCharacterClass03" xml:space="preserve"><value>Templer</value></data>
-  <data name="xtagCharacterClass04" xml:space="preserve"><value>Evoker</value></data>
-  <data name="xtagCharacterClass05" xml:space="preserve"><value>Prophet</value></data>
-  <data name="xtagCharacterClass06" xml:space="preserve"><value>Haruspex</value></data>
-  <data name="xtagCharacterClass07" xml:space="preserve"><value>Traumtöter</value></data>
-  <data name="xtagCharacterClass08" xml:space="preserve"><value>Ritualist</value></data>
-  <data name="xtagCharacterClass09" xml:space="preserve"><value>Wahrsager</value></data>
-  <data name="x2tag_class_rm_rm" xml:space="preserve"><value>Runenmeister</value></data>
-  <data name="x2tag_class_warfare_rm" xml:space="preserve"><value>Berserker</value></data>
-  <data name="x2tag_class_defense_rm" xml:space="preserve"><value>Runenschmied</value></data>
-  <data name="x2tag_class_earth_rm" xml:space="preserve"><value>Steinsprecher</value></data>
-  <data name="x2tag_class_storm_rm" xml:space="preserve"><value>Donnerer</value></data>
-  <data name="x2tag_class_hunting_rm" xml:space="preserve"><value>Drachenjäger</value></data>
-  <data name="x2tag_class_stealth_rm" xml:space="preserve"><value>Betrüger</value></data>
-  <data name="x2tag_class_nature_rm" xml:space="preserve"><value>Hautwechsler</value></data>
-  <data name="x2tag_class_spirit_rm" xml:space="preserve"><value>Schamane</value></data>
-  <data name="x2tag_class_dream_rm" xml:space="preserve"><value>Seidr Arbeiter</value></data>
-
-  <data name="CurrentLevel" xml:space="preserve"><value>Niveau</value></data>
-  <data name="Class" xml:space="preserve"><value>Klasse</value></data>
-  <data name="CurrentXP" xml:space="preserve"><value>XP</value></data>
-  <data name="DifficultyUnlocked" xml:space="preserve"><value>Schwierigkeit</value></data>
-  <data name="Money" xml:space="preserve"><value>Geld</value></data>
-  <data name="SkillPoints" xml:space="preserve"><value>Erfahrungspunkte</value></data>
-  <data name="AttributesPoints" xml:space="preserve"><value>Attributpunkte</value></data>
-  <data name="BaseStrength" xml:space="preserve"><value>Basisstr</value></data>
-  <data name="BaseDexterity" xml:space="preserve"><value>Base Dex</value></data>
-  <data name="BaseIntelligence" xml:space="preserve"><value>Base Int</value></data>
-  <data name="BaseHealth" xml:space="preserve"><value>Basiszustand</value></data>
-  <data name="BaseMana" xml:space="preserve"><value>Basis Mana</value></data>
-  <data name="PlayTimeInSeconds" xml:space="preserve"><value>Spielzeit</value></data>
-  <data name="NumberOfDeaths" xml:space="preserve"><value>Todesfälle</value></data>
-  <data name="NumberOfKills" xml:space="preserve"><value>Tötet</value></data>
-  <data name="ExperienceFromKills" xml:space="preserve"><value>XP von Kills</value></data>
-  <data name="HealthPotionsUsed" xml:space="preserve"><value>Gesundheitstöpfe</value></data>
-  <data name="ManaPotionsUsed" xml:space="preserve"><value>Mana Pots</value></data>
-  <data name="MaxLevel" xml:space="preserve"><value>Maximales Level</value></data>
-  <data name="NumHitsReceived" xml:space="preserve"><value>Hits Recv</value></data>
-  <data name="NumHitsInflicted" xml:space="preserve"><value>Treffer zugefügt</value></data>
-  <data name="GreatestDamageInflicted" xml:space="preserve"><value>Größtes Dmg</value></data>
-  <data name="GreatestMonster" xml:space="preserve"><value>Größter Mob</value></data>
-  <data name="CriticalHitsInflicted" xml:space="preserve"><value>Kritische Treffer</value></data>
-  <data name="CriticalHitsReceived" xml:space="preserve"><value>Kritische Treffer</value></data>
-
+  <data name="tagCClass01" xml:space="preserve">
+    <value>Theurgist</value>
+  </data>
+  <data name="tagCClass02" xml:space="preserve">
+    <value>Wanderer</value>
+  </data>
+  <data name="tagCClass03" xml:space="preserve">
+    <value>Schurke</value>
+  </data>
+  <data name="tagCClass04" xml:space="preserve">
+    <value>Jäger</value>
+  </data>
+  <data name="tagCClass05" xml:space="preserve">
+    <value>Sturmrufer</value>
+  </data>
+  <data name="tagCClass06" xml:space="preserve">
+    <value>Pyromant</value>
+  </data>
+  <data name="tagCClass07" xml:space="preserve">
+    <value>Verteidiger</value>
+  </data>
+  <data name="tagCClass08" xml:space="preserve">
+    <value>Krieger</value>
+  </data>
+  <data name="tagCClass09" xml:space="preserve">
+    <value>Zauberbrecher</value>
+  </data>
+  <data name="tagCClass10" xml:space="preserve">
+    <value>Champion</value>
+  </data>
+  <data name="tagCClass11" xml:space="preserve">
+    <value>Attentäter</value>
+  </data>
+  <data name="tagCClass12" xml:space="preserve">
+    <value>Jägerin</value>
+  </data>
+  <data name="tagCClass13" xml:space="preserve">
+    <value>Thane</value>
+  </data>
+  <data name="tagCClass14" xml:space="preserve">
+    <value>Kampfmagier</value>
+  </data>
+  <data name="tagCClass15" xml:space="preserve">
+    <value>Eroberer</value>
+  </data>
+  <data name="tagCClass16" xml:space="preserve">
+    <value>Zauberbinder</value>
+  </data>
+  <data name="tagCClass17" xml:space="preserve">
+    <value>Wächter</value>
+  </data>
+  <data name="tagCClass18" xml:space="preserve">
+    <value>Korsar</value>
+  </data>
+  <data name="tagCClass19" xml:space="preserve">
+    <value>Aufseher</value>
+  </data>
+  <data name="tagCClass20" xml:space="preserve">
+    <value>Paladin</value>
+  </data>
+  <data name="tagCClass21" xml:space="preserve">
+    <value>Moloch</value>
+  </data>
+  <data name="tagCClass22" xml:space="preserve">
+    <value>Zauberkünstler</value>
+  </data>
+  <data name="tagCClass23" xml:space="preserve">
+    <value>Beschwörer</value>
+  </data>
+  <data name="tagCClass24" xml:space="preserve">
+    <value>Zauberer</value>
+  </data>
+  <data name="tagCClass25" xml:space="preserve">
+    <value>Rächer</value>
+  </data>
+  <data name="tagCClass26" xml:space="preserve">
+    <value>Elementalist</value>
+  </data>
+  <data name="tagCClass27" xml:space="preserve">
+    <value>Orakel</value>
+  </data>
+  <data name="tagCClass28" xml:space="preserve">
+    <value>Druide</value>
+  </data>
+  <data name="tagCClass29" xml:space="preserve">
+    <value>Zauberer</value>
+  </data>
+  <data name="tagCClass30" xml:space="preserve">
+    <value>Salbei</value>
+  </data>
+  <data name="tagCClass31" xml:space="preserve">
+    <value>Knochenbeschwörer</value>
+  </data>
+  <data name="tagCClass32" xml:space="preserve">
+    <value>Ranger</value>
+  </data>
+  <data name="tagCClass33" xml:space="preserve">
+    <value>Räuber</value>
+  </data>
+  <data name="tagCClass34" xml:space="preserve">
+    <value>Hexenmeister</value>
+  </data>
+  <data name="tagCClass35" xml:space="preserve">
+    <value>Illusionist</value>
+  </data>
+  <data name="tagCClass36" xml:space="preserve">
+    <value>Wahrsager</value>
+  </data>
+  <data name="xtagCharacterClass01" xml:space="preserve">
+    <value>Seher</value>
+  </data>
+  <data name="xtagCharacterClass02" xml:space="preserve">
+    <value>Vorbote</value>
+  </data>
+  <data name="xtagCharacterClass03" xml:space="preserve">
+    <value>Templer</value>
+  </data>
+  <data name="xtagCharacterClass04" xml:space="preserve">
+    <value>Evoker</value>
+  </data>
+  <data name="xtagCharacterClass05" xml:space="preserve">
+    <value>Prophet</value>
+  </data>
+  <data name="xtagCharacterClass06" xml:space="preserve">
+    <value>Haruspex</value>
+  </data>
+  <data name="xtagCharacterClass07" xml:space="preserve">
+    <value>Traumtöter</value>
+  </data>
+  <data name="xtagCharacterClass08" xml:space="preserve">
+    <value>Ritualist</value>
+  </data>
+  <data name="xtagCharacterClass09" xml:space="preserve">
+    <value>Wahrsager</value>
+  </data>
+  <data name="x2tag_class_rm_rm" xml:space="preserve">
+    <value>Runenmeister</value>
+  </data>
+  <data name="x2tag_class_warfare_rm" xml:space="preserve">
+    <value>Berserker</value>
+  </data>
+  <data name="x2tag_class_defense_rm" xml:space="preserve">
+    <value>Runenschmied</value>
+  </data>
+  <data name="x2tag_class_earth_rm" xml:space="preserve">
+    <value>Steinsprecher</value>
+  </data>
+  <data name="x2tag_class_storm_rm" xml:space="preserve">
+    <value>Donnerer</value>
+  </data>
+  <data name="x2tag_class_hunting_rm" xml:space="preserve">
+    <value>Drachenjäger</value>
+  </data>
+  <data name="x2tag_class_stealth_rm" xml:space="preserve">
+    <value>Betrüger</value>
+  </data>
+  <data name="x2tag_class_nature_rm" xml:space="preserve">
+    <value>Hautwechsler</value>
+  </data>
+  <data name="x2tag_class_spirit_rm" xml:space="preserve">
+    <value>Schamane</value>
+  </data>
+  <data name="x2tag_class_dream_rm" xml:space="preserve">
+    <value>Seidr Arbeiter</value>
+  </data>
+  <data name="CurrentLevel" xml:space="preserve">
+    <value>Niveau</value>
+  </data>
+  <data name="Class" xml:space="preserve">
+    <value>Klasse</value>
+  </data>
+  <data name="CurrentXP" xml:space="preserve">
+    <value>XP</value>
+  </data>
+  <data name="DifficultyUnlocked" xml:space="preserve">
+    <value>Schwierigkeit</value>
+  </data>
+  <data name="Money" xml:space="preserve">
+    <value>Geld</value>
+  </data>
+  <data name="SkillPoints" xml:space="preserve">
+    <value>Erfahrungspunkte</value>
+  </data>
+  <data name="AttributesPoints" xml:space="preserve">
+    <value>Attributpunkte</value>
+  </data>
+  <data name="BaseStrength" xml:space="preserve">
+    <value>Basisstr</value>
+  </data>
+  <data name="BaseDexterity" xml:space="preserve">
+    <value>Base Dex</value>
+  </data>
+  <data name="BaseIntelligence" xml:space="preserve">
+    <value>Base Int</value>
+  </data>
+  <data name="BaseHealth" xml:space="preserve">
+    <value>Basiszustand</value>
+  </data>
+  <data name="BaseMana" xml:space="preserve">
+    <value>Basis Mana</value>
+  </data>
+  <data name="PlayTimeInSeconds" xml:space="preserve">
+    <value>Spielzeit</value>
+  </data>
+  <data name="NumberOfDeaths" xml:space="preserve">
+    <value>Todesfälle</value>
+  </data>
+  <data name="NumberOfKills" xml:space="preserve">
+    <value>Tötet</value>
+  </data>
+  <data name="ExperienceFromKills" xml:space="preserve">
+    <value>XP von Kills</value>
+  </data>
+  <data name="HealthPotionsUsed" xml:space="preserve">
+    <value>Gesundheitstöpfe</value>
+  </data>
+  <data name="ManaPotionsUsed" xml:space="preserve">
+    <value>Mana Pots</value>
+  </data>
+  <data name="MaxLevel" xml:space="preserve">
+    <value>Maximales Level</value>
+  </data>
+  <data name="NumHitsReceived" xml:space="preserve">
+    <value>Hits Recv</value>
+  </data>
+  <data name="NumHitsInflicted" xml:space="preserve">
+    <value>Treffer zugefügt</value>
+  </data>
+  <data name="GreatestDamageInflicted" xml:space="preserve">
+    <value>Größtes Dmg</value>
+  </data>
+  <data name="GreatestMonster" xml:space="preserve">
+    <value>Größter Mob</value>
+  </data>
+  <data name="CriticalHitsInflicted" xml:space="preserve">
+    <value>Kritische Treffer</value>
+  </data>
+  <data name="CriticalHitsReceived" xml:space="preserve">
+    <value>Kritische Treffer</value>
+  </data>
 </root>

--- a/src/TQVaultAE.Presentation/Resources.es.resx
+++ b/src/TQVaultAE.Presentation/Resources.es.resx
@@ -112,10 +112,10 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AboutDescription" xml:space="preserve">
     <value>TQVault desarrollado por bman654 (wickedsoul_@yahoo.com) 
@@ -986,7 +986,6 @@ He aquí un ejemplo complejo: 'glacial &amp; hielo @espada $raro'</value>
   <data name="GlobalRelicVaultStash" xml:space="preserve">
     <value>Almacén de Reliquias</value>
   </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="SettingsAllowEditCE" xml:space="preserve">
     <value>Permitir características de edición de caracteres</value>
   </data>
@@ -1013,9 +1012,6 @@ He aquí un ejemplo complejo: 'glacial &amp; hielo @espada $raro'</value>
   </data>
   <data name="CEEnableLeveling" xml:space="preserve">
     <value>Habilitar nivelación</value>
-  </data>
-  <data name="CEEnableRedistribute" xml:space="preserve">
-    <value>Habilitar redistribuir</value>
   </data>
   <data name="CEHealth" xml:space="preserve">
     <value>Salud</value>
@@ -1044,87 +1040,244 @@ He aquí un ejemplo complejo: 'glacial &amp; hielo @espada $raro'</value>
   <data name="CharacterEditBtn" xml:space="preserve">
     <value>Editar</value>
   </data>
-
-  <data name="tagCClass01" xml:space="preserve"><value>Teurgista</value></data>
-  <data name="tagCClass02" xml:space="preserve"><value>Vagabundo</value></data>
-  <data name="tagCClass03" xml:space="preserve"><value>Pícaro</value></data>
-  <data name="tagCClass04" xml:space="preserve"><value>Cazador</value></data>
-  <data name="tagCClass05" xml:space="preserve"><value>Stormcaller</value></data>
-  <data name="tagCClass06" xml:space="preserve"><value>Piromante</value></data>
-  <data name="tagCClass07" xml:space="preserve"><value>Defensor</value></data>
-  <data name="tagCClass08" xml:space="preserve"><value>Guerrero</value></data>
-  <data name="tagCClass09" xml:space="preserve"><value>Rompehechizos</value></data>
-  <data name="tagCClass10" xml:space="preserve"><value>Campeón</value></data>
-  <data name="tagCClass11" xml:space="preserve"><value>Asesino</value></data>
-  <data name="tagCClass12" xml:space="preserve"><value>Asesino</value></data>
-  <data name="tagCClass13" xml:space="preserve"><value>Thane</value></data>
-  <data name="tagCClass14" xml:space="preserve"><value>Mago de batalla</value></data>
-  <data name="tagCClass15" xml:space="preserve"><value>Conquistador</value></data>
-  <data name="tagCClass16" xml:space="preserve"><value>Orador fascinante</value></data>
-  <data name="tagCClass17" xml:space="preserve"><value>guardián</value></data>
-  <data name="tagCClass18" xml:space="preserve"><value>Corsario</value></data>
-  <data name="tagCClass19" xml:space="preserve"><value>Guardián</value></data>
-  <data name="tagCClass20" xml:space="preserve"><value>Paladín</value></data>
-  <data name="tagCClass21" xml:space="preserve"><value>Juggernaut</value></data>
-  <data name="tagCClass22" xml:space="preserve"><value>Prestidigitador</value></data>
-  <data name="tagCClass23" xml:space="preserve"><value>Invocador</value></data>
-  <data name="tagCClass24" xml:space="preserve"><value>Mago</value></data>
-  <data name="tagCClass25" xml:space="preserve"><value>Vengador</value></data>
-  <data name="tagCClass26" xml:space="preserve"><value>Elementalista</value></data>
-  <data name="tagCClass27" xml:space="preserve"><value>Oráculo</value></data>
-  <data name="tagCClass28" xml:space="preserve"><value>druida</value></data>
-  <data name="tagCClass29" xml:space="preserve"><value>Hechicero</value></data>
-  <data name="tagCClass30" xml:space="preserve"><value>Sabio</value></data>
-  <data name="tagCClass31" xml:space="preserve"><value>Encantador de huesos</value></data>
-  <data name="tagCClass32" xml:space="preserve"><value>guardabosque</value></data>
-  <data name="tagCClass33" xml:space="preserve"><value>Bandido</value></data>
-  <data name="tagCClass34" xml:space="preserve"><value>Brujo</value></data>
-  <data name="tagCClass35" xml:space="preserve"><value>Ilusionista</value></data>
-  <data name="tagCClass36" xml:space="preserve"><value>Adivino</value></data>
-  <data name="xtagCharacterClass01" xml:space="preserve"><value>Vidente</value></data>
-  <data name="xtagCharacterClass02" xml:space="preserve"><value>Presagio</value></data>
-  <data name="xtagCharacterClass03" xml:space="preserve"><value>Templario</value></data>
-  <data name="xtagCharacterClass04" xml:space="preserve"><value>Evoker</value></data>
-  <data name="xtagCharacterClass05" xml:space="preserve"><value>Profeta</value></data>
-  <data name="xtagCharacterClass06" xml:space="preserve"><value>Aruspex</value></data>
-  <data name="xtagCharacterClass07" xml:space="preserve"><value>Asesino de sueños</value></data>
-  <data name="xtagCharacterClass08" xml:space="preserve"><value>Ritualista</value></data>
-  <data name="xtagCharacterClass09" xml:space="preserve"><value>Adivino</value></data>
-  <data name="x2tag_class_rm_rm" xml:space="preserve"><value>Runemaster</value></data>
-  <data name="x2tag_class_warfare_rm" xml:space="preserve"><value>frenético</value></data>
-  <data name="x2tag_class_defense_rm" xml:space="preserve"><value>Runesmith</value></data>
-  <data name="x2tag_class_earth_rm" xml:space="preserve"><value>Hablador de piedras</value></data>
-  <data name="x2tag_class_storm_rm" xml:space="preserve"><value>Trueno</value></data>
-  <data name="x2tag_class_hunting_rm" xml:space="preserve"><value>Cazador de Dragon</value></data>
-  <data name="x2tag_class_stealth_rm" xml:space="preserve"><value>Embaucador</value></data>
-  <data name="x2tag_class_nature_rm" xml:space="preserve"><value>Skinchanger</value></data>
-  <data name="x2tag_class_spirit_rm" xml:space="preserve"><value>Chamán</value></data>
-  <data name="x2tag_class_dream_rm" xml:space="preserve"><value>Trabajador seidr</value></data>
-
-  <data name="CurrentLevel" xml:space="preserve"><value>Nivel</value></data>
-  <data name="Class" xml:space="preserve"><value>Clase</value></data>
-  <data name="CurrentXP" xml:space="preserve"><value>XP</value></data>
-  <data name="DifficultyUnlocked" xml:space="preserve"><value>Dificultad</value></data>
-  <data name="Money" xml:space="preserve"><value>Dinero</value></data>
-  <data name="SkillPoints" xml:space="preserve"><value>Habilidades</value></data>
-  <data name="AttributesPoints" xml:space="preserve"><value>Puntos de atributo</value></data>
-  <data name="BaseStrength" xml:space="preserve"><value>Base Str</value></data>
-  <data name="BaseDexterity" xml:space="preserve"><value>Base Dex</value></data>
-  <data name="BaseIntelligence" xml:space="preserve"><value>Base Int</value></data>
-  <data name="BaseHealth" xml:space="preserve"><value>Base de Salud</value></data>
-  <data name="BaseMana" xml:space="preserve"><value>Base Mana</value></data>
-  <data name="PlayTimeInSeconds" xml:space="preserve"><value>Tiempo jugado</value></data>
-  <data name="NumberOfDeaths" xml:space="preserve"><value>Muertes</value></data>
-  <data name="NumberOfKills" xml:space="preserve"><value>Mata</value></data>
-  <data name="ExperienceFromKills" xml:space="preserve"><value>XP de muertes</value></data>
-  <data name="HealthPotionsUsed" xml:space="preserve"><value>Ollas de salud</value></data>
-  <data name="ManaPotionsUsed" xml:space="preserve"><value>Macetas De Maná</value></data>
-  <data name="MaxLevel" xml:space="preserve"><value>Máximo nivel</value></data>
-  <data name="NumHitsReceived" xml:space="preserve"><value>Hits Recv</value></data>
-  <data name="NumHitsInflicted" xml:space="preserve"><value>Golpes infligidos</value></data>
-  <data name="GreatestDamageInflicted" xml:space="preserve"><value>Mayor dmg</value></data>
-  <data name="GreatestMonster" xml:space="preserve"><value>La mafia mas grande</value></data>
-  <data name="CriticalHitsInflicted" xml:space="preserve"><value>Golpes críticos</value></data>
-  <data name="CriticalHitsReceived" xml:space="preserve"><value>Críticas tomadas</value></data>
-
+  <data name="tagCClass01" xml:space="preserve">
+    <value>Teurgista</value>
+  </data>
+  <data name="tagCClass02" xml:space="preserve">
+    <value>Vagabundo</value>
+  </data>
+  <data name="tagCClass03" xml:space="preserve">
+    <value>Pícaro</value>
+  </data>
+  <data name="tagCClass04" xml:space="preserve">
+    <value>Cazador</value>
+  </data>
+  <data name="tagCClass05" xml:space="preserve">
+    <value>Stormcaller</value>
+  </data>
+  <data name="tagCClass06" xml:space="preserve">
+    <value>Piromante</value>
+  </data>
+  <data name="tagCClass07" xml:space="preserve">
+    <value>Defensor</value>
+  </data>
+  <data name="tagCClass08" xml:space="preserve">
+    <value>Guerrero</value>
+  </data>
+  <data name="tagCClass09" xml:space="preserve">
+    <value>Rompehechizos</value>
+  </data>
+  <data name="tagCClass10" xml:space="preserve">
+    <value>Campeón</value>
+  </data>
+  <data name="tagCClass11" xml:space="preserve">
+    <value>Asesino</value>
+  </data>
+  <data name="tagCClass12" xml:space="preserve">
+    <value>Asesino</value>
+  </data>
+  <data name="tagCClass13" xml:space="preserve">
+    <value>Thane</value>
+  </data>
+  <data name="tagCClass14" xml:space="preserve">
+    <value>Mago de batalla</value>
+  </data>
+  <data name="tagCClass15" xml:space="preserve">
+    <value>Conquistador</value>
+  </data>
+  <data name="tagCClass16" xml:space="preserve">
+    <value>Orador fascinante</value>
+  </data>
+  <data name="tagCClass17" xml:space="preserve">
+    <value>guardián</value>
+  </data>
+  <data name="tagCClass18" xml:space="preserve">
+    <value>Corsario</value>
+  </data>
+  <data name="tagCClass19" xml:space="preserve">
+    <value>Guardián</value>
+  </data>
+  <data name="tagCClass20" xml:space="preserve">
+    <value>Paladín</value>
+  </data>
+  <data name="tagCClass21" xml:space="preserve">
+    <value>Juggernaut</value>
+  </data>
+  <data name="tagCClass22" xml:space="preserve">
+    <value>Prestidigitador</value>
+  </data>
+  <data name="tagCClass23" xml:space="preserve">
+    <value>Invocador</value>
+  </data>
+  <data name="tagCClass24" xml:space="preserve">
+    <value>Mago</value>
+  </data>
+  <data name="tagCClass25" xml:space="preserve">
+    <value>Vengador</value>
+  </data>
+  <data name="tagCClass26" xml:space="preserve">
+    <value>Elementalista</value>
+  </data>
+  <data name="tagCClass27" xml:space="preserve">
+    <value>Oráculo</value>
+  </data>
+  <data name="tagCClass28" xml:space="preserve">
+    <value>druida</value>
+  </data>
+  <data name="tagCClass29" xml:space="preserve">
+    <value>Hechicero</value>
+  </data>
+  <data name="tagCClass30" xml:space="preserve">
+    <value>Sabio</value>
+  </data>
+  <data name="tagCClass31" xml:space="preserve">
+    <value>Encantador de huesos</value>
+  </data>
+  <data name="tagCClass32" xml:space="preserve">
+    <value>guardabosque</value>
+  </data>
+  <data name="tagCClass33" xml:space="preserve">
+    <value>Bandido</value>
+  </data>
+  <data name="tagCClass34" xml:space="preserve">
+    <value>Brujo</value>
+  </data>
+  <data name="tagCClass35" xml:space="preserve">
+    <value>Ilusionista</value>
+  </data>
+  <data name="tagCClass36" xml:space="preserve">
+    <value>Adivino</value>
+  </data>
+  <data name="xtagCharacterClass01" xml:space="preserve">
+    <value>Vidente</value>
+  </data>
+  <data name="xtagCharacterClass02" xml:space="preserve">
+    <value>Presagio</value>
+  </data>
+  <data name="xtagCharacterClass03" xml:space="preserve">
+    <value>Templario</value>
+  </data>
+  <data name="xtagCharacterClass04" xml:space="preserve">
+    <value>Evoker</value>
+  </data>
+  <data name="xtagCharacterClass05" xml:space="preserve">
+    <value>Profeta</value>
+  </data>
+  <data name="xtagCharacterClass06" xml:space="preserve">
+    <value>Aruspex</value>
+  </data>
+  <data name="xtagCharacterClass07" xml:space="preserve">
+    <value>Asesino de sueños</value>
+  </data>
+  <data name="xtagCharacterClass08" xml:space="preserve">
+    <value>Ritualista</value>
+  </data>
+  <data name="xtagCharacterClass09" xml:space="preserve">
+    <value>Adivino</value>
+  </data>
+  <data name="x2tag_class_rm_rm" xml:space="preserve">
+    <value>Runemaster</value>
+  </data>
+  <data name="x2tag_class_warfare_rm" xml:space="preserve">
+    <value>frenético</value>
+  </data>
+  <data name="x2tag_class_defense_rm" xml:space="preserve">
+    <value>Runesmith</value>
+  </data>
+  <data name="x2tag_class_earth_rm" xml:space="preserve">
+    <value>Hablador de piedras</value>
+  </data>
+  <data name="x2tag_class_storm_rm" xml:space="preserve">
+    <value>Trueno</value>
+  </data>
+  <data name="x2tag_class_hunting_rm" xml:space="preserve">
+    <value>Cazador de Dragon</value>
+  </data>
+  <data name="x2tag_class_stealth_rm" xml:space="preserve">
+    <value>Embaucador</value>
+  </data>
+  <data name="x2tag_class_nature_rm" xml:space="preserve">
+    <value>Skinchanger</value>
+  </data>
+  <data name="x2tag_class_spirit_rm" xml:space="preserve">
+    <value>Chamán</value>
+  </data>
+  <data name="x2tag_class_dream_rm" xml:space="preserve">
+    <value>Trabajador seidr</value>
+  </data>
+  <data name="CurrentLevel" xml:space="preserve">
+    <value>Nivel</value>
+  </data>
+  <data name="Class" xml:space="preserve">
+    <value>Clase</value>
+  </data>
+  <data name="CurrentXP" xml:space="preserve">
+    <value>XP</value>
+  </data>
+  <data name="DifficultyUnlocked" xml:space="preserve">
+    <value>Dificultad</value>
+  </data>
+  <data name="Money" xml:space="preserve">
+    <value>Dinero</value>
+  </data>
+  <data name="SkillPoints" xml:space="preserve">
+    <value>Habilidades</value>
+  </data>
+  <data name="AttributesPoints" xml:space="preserve">
+    <value>Puntos de atributo</value>
+  </data>
+  <data name="BaseStrength" xml:space="preserve">
+    <value>Base Str</value>
+  </data>
+  <data name="BaseDexterity" xml:space="preserve">
+    <value>Base Dex</value>
+  </data>
+  <data name="BaseIntelligence" xml:space="preserve">
+    <value>Base Int</value>
+  </data>
+  <data name="BaseHealth" xml:space="preserve">
+    <value>Base de Salud</value>
+  </data>
+  <data name="BaseMana" xml:space="preserve">
+    <value>Base Mana</value>
+  </data>
+  <data name="PlayTimeInSeconds" xml:space="preserve">
+    <value>Tiempo jugado</value>
+  </data>
+  <data name="NumberOfDeaths" xml:space="preserve">
+    <value>Muertes</value>
+  </data>
+  <data name="NumberOfKills" xml:space="preserve">
+    <value>Mata</value>
+  </data>
+  <data name="ExperienceFromKills" xml:space="preserve">
+    <value>XP de muertes</value>
+  </data>
+  <data name="HealthPotionsUsed" xml:space="preserve">
+    <value>Ollas de salud</value>
+  </data>
+  <data name="ManaPotionsUsed" xml:space="preserve">
+    <value>Macetas De Maná</value>
+  </data>
+  <data name="MaxLevel" xml:space="preserve">
+    <value>Máximo nivel</value>
+  </data>
+  <data name="NumHitsReceived" xml:space="preserve">
+    <value>Hits Recv</value>
+  </data>
+  <data name="NumHitsInflicted" xml:space="preserve">
+    <value>Golpes infligidos</value>
+  </data>
+  <data name="GreatestDamageInflicted" xml:space="preserve">
+    <value>Mayor dmg</value>
+  </data>
+  <data name="GreatestMonster" xml:space="preserve">
+    <value>La mafia mas grande</value>
+  </data>
+  <data name="CriticalHitsInflicted" xml:space="preserve">
+    <value>Golpes críticos</value>
+  </data>
+  <data name="CriticalHitsReceived" xml:space="preserve">
+    <value>Críticas tomadas</value>
+  </data>
 </root>

--- a/src/TQVaultAE.Presentation/Resources.fr.resx
+++ b/src/TQVaultAE.Presentation/Resources.fr.resx
@@ -112,10 +112,10 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AboutDescription" xml:space="preserve">
     <value>TQVault par bman654 (wickedsoul_@yahoo.com)
@@ -989,7 +989,6 @@ Voici un exemple complexe: 'arctique &amp; gel @sabre $épique | rare'</value>
   <data name="GlobalRelicVaultStash" xml:space="preserve">
     <value>Chambre des reliques</value>
   </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="SettingsAllowEditCE" xml:space="preserve">
     <value>Allow Character Editing Features</value>
   </data>
@@ -1001,7 +1000,7 @@ Voici un exemple complexe: 'arctique &amp; gel @sabre $épique | rare'</value>
   </data>
   <data name="Difficulty2" xml:space="preserve">
     <value>Légendaire</value>
-  </data>  
+  </data>
   <data name="CEAttributePoints" xml:space="preserve">
     <value>Points d'attributs</value>
   </data>
@@ -1016,9 +1015,6 @@ Voici un exemple complexe: 'arctique &amp; gel @sabre $épique | rare'</value>
   </data>
   <data name="CEEnableLeveling" xml:space="preserve">
     <value>Activer le nivellement</value>
-  </data>
-  <data name="CEEnableRedistribute" xml:space="preserve">
-    <value>Activer la redistribution</value>
   </data>
   <data name="CEHealth" xml:space="preserve">
     <value>Santé</value>
@@ -1047,87 +1043,244 @@ Voici un exemple complexe: 'arctique &amp; gel @sabre $épique | rare'</value>
   <data name="CharacterEditBtn" xml:space="preserve">
     <value>modifier</value>
   </data>
-
-  <data name="tagCClass01" xml:space="preserve"><value>Théurgiste</value></data>
-  <data name="tagCClass02" xml:space="preserve"><value>Vagabond</value></data>
-  <data name="tagCClass03" xml:space="preserve"><value>Coquin</value></data>
-  <data name="tagCClass04" xml:space="preserve"><value>chasseur</value></data>
-  <data name="tagCClass05" xml:space="preserve"><value>Stormcaller</value></data>
-  <data name="tagCClass06" xml:space="preserve"><value>Pyromancien</value></data>
-  <data name="tagCClass07" xml:space="preserve"><value>Défenseur</value></data>
-  <data name="tagCClass08" xml:space="preserve"><value>guerrier</value></data>
-  <data name="tagCClass09" xml:space="preserve"><value>Briseur de sorts</value></data>
-  <data name="tagCClass10" xml:space="preserve"><value>Champion</value></data>
-  <data name="tagCClass11" xml:space="preserve"><value>Assassin</value></data>
-  <data name="tagCClass12" xml:space="preserve"><value>Tueur</value></data>
-  <data name="tagCClass13" xml:space="preserve"><value>Thane</value></data>
-  <data name="tagCClass14" xml:space="preserve"><value>Battlemage</value></data>
-  <data name="tagCClass15" xml:space="preserve"><value>Conquérant</value></data>
-  <data name="tagCClass16" xml:space="preserve"><value>Relieur d'orthographe</value></data>
-  <data name="tagCClass17" xml:space="preserve"><value>Gardien</value></data>
-  <data name="tagCClass18" xml:space="preserve"><value>Corsaire</value></data>
-  <data name="tagCClass19" xml:space="preserve"><value>Directeur</value></data>
-  <data name="tagCClass20" xml:space="preserve"><value>Paladin</value></data>
-  <data name="tagCClass21" xml:space="preserve"><value>Juggernaut</value></data>
-  <data name="tagCClass22" xml:space="preserve"><value>Illusionniste</value></data>
-  <data name="tagCClass23" xml:space="preserve"><value>Invocateur</value></data>
-  <data name="tagCClass24" xml:space="preserve"><value>Magicien</value></data>
-  <data name="tagCClass25" xml:space="preserve"><value>Vengeur</value></data>
-  <data name="tagCClass26" xml:space="preserve"><value>Élémentaliste</value></data>
-  <data name="tagCClass27" xml:space="preserve"><value>Oracle</value></data>
-  <data name="tagCClass28" xml:space="preserve"><value>Druide</value></data>
-  <data name="tagCClass29" xml:space="preserve"><value>Sorcier</value></data>
-  <data name="tagCClass30" xml:space="preserve"><value>sauge</value></data>
-  <data name="tagCClass31" xml:space="preserve"><value>Charmeur d'os</value></data>
-  <data name="tagCClass32" xml:space="preserve"><value>Ranger</value></data>
-  <data name="tagCClass33" xml:space="preserve"><value>Brigand</value></data>
-  <data name="tagCClass34" xml:space="preserve"><value>démoniste</value></data>
-  <data name="tagCClass35" xml:space="preserve"><value>Illusionniste</value></data>
-  <data name="tagCClass36" xml:space="preserve"><value>Devin</value></data>
-  <data name="xtagCharacterClass01" xml:space="preserve"><value>Voyant</value></data>
-  <data name="xtagCharacterClass02" xml:space="preserve"><value>Présage</value></data>
-  <data name="xtagCharacterClass03" xml:space="preserve"><value>Templier</value></data>
-  <data name="xtagCharacterClass04" xml:space="preserve"><value>Evoker</value></data>
-  <data name="xtagCharacterClass05" xml:space="preserve"><value>Prophète</value></data>
-  <data name="xtagCharacterClass06" xml:space="preserve"><value>Haruspex</value></data>
-  <data name="xtagCharacterClass07" xml:space="preserve"><value>Dreamkiller</value></data>
-  <data name="xtagCharacterClass08" xml:space="preserve"><value>Ritualiste</value></data>
-  <data name="xtagCharacterClass09" xml:space="preserve"><value>Devin</value></data>
-  <data name="x2tag_class_rm_rm" xml:space="preserve"><value>Maître des runes</value></data>
-  <data name="x2tag_class_warfare_rm" xml:space="preserve"><value>Berserker</value></data>
-  <data name="x2tag_class_defense_rm" xml:space="preserve"><value>Runesmith</value></data>
-  <data name="x2tag_class_earth_rm" xml:space="preserve"><value>Pierrespeaker</value></data>
-  <data name="x2tag_class_storm_rm" xml:space="preserve"><value>Thunderer</value></data>
-  <data name="x2tag_class_hunting_rm" xml:space="preserve"><value>Chasseur de dragon</value></data>
-  <data name="x2tag_class_stealth_rm" xml:space="preserve"><value>Filou</value></data>
-  <data name="x2tag_class_nature_rm" xml:space="preserve"><value>Skinchanger</value></data>
-  <data name="x2tag_class_spirit_rm" xml:space="preserve"><value>Chaman</value></data>
-  <data name="x2tag_class_dream_rm" xml:space="preserve"><value>Seidr Worker</value></data>
-
-  <data name="CurrentLevel" xml:space="preserve"><value>Niveau</value></data>
-  <data name="Class" xml:space="preserve"><value>Classe</value></data>
-  <data name="CurrentXP" xml:space="preserve"><value>XP</value></data>
-  <data name="DifficultyUnlocked" xml:space="preserve"><value>Difficulté</value></data>
-  <data name="Money" xml:space="preserve"><value>Argent</value></data>
-  <data name="SkillPoints" xml:space="preserve"><value>compétences</value></data>
-  <data name="AttributesPoints" xml:space="preserve"><value>Points d'attributs</value></data>
-  <data name="BaseStrength" xml:space="preserve"><value>Base Str</value></data>
-  <data name="BaseDexterity" xml:space="preserve"><value>Base Dex</value></data>
-  <data name="BaseIntelligence" xml:space="preserve"><value>Base Int</value></data>
-  <data name="BaseHealth" xml:space="preserve"><value>Santé de base</value></data>
-  <data name="BaseMana" xml:space="preserve"><value>Mana de base</value></data>
-  <data name="PlayTimeInSeconds" xml:space="preserve"><value>Temps joué</value></data>
-  <data name="NumberOfDeaths" xml:space="preserve"><value>Des morts</value></data>
-  <data name="NumberOfKills" xml:space="preserve"><value>Tue</value></data>
-  <data name="ExperienceFromKills" xml:space="preserve"><value>XP de Kills</value></data>
-  <data name="HealthPotionsUsed" xml:space="preserve"><value>santé utilisés</value></data>
-  <data name="ManaPotionsUsed" xml:space="preserve"><value>mana utilisés</value></data>
-  <data name="MaxLevel" xml:space="preserve"><value>Niveau maximum</value></data>
-  <data name="NumHitsReceived" xml:space="preserve"><value>Hits recv</value></data>
-  <data name="NumHitsInflicted" xml:space="preserve"><value>Hits infligés</value></data>
-  <data name="GreatestDamageInflicted" xml:space="preserve"><value>Plus grand Dmg</value></data>
-  <data name="GreatestMonster" xml:space="preserve"><value>Plus grand mob</value></data>
-  <data name="CriticalHitsInflicted" xml:space="preserve"><value>Coups critiques</value></data>
-  <data name="CriticalHitsReceived" xml:space="preserve"><value>Coups critiques</value></data>
-
+  <data name="tagCClass01" xml:space="preserve">
+    <value>Théurgiste</value>
+  </data>
+  <data name="tagCClass02" xml:space="preserve">
+    <value>Vagabond</value>
+  </data>
+  <data name="tagCClass03" xml:space="preserve">
+    <value>Coquin</value>
+  </data>
+  <data name="tagCClass04" xml:space="preserve">
+    <value>chasseur</value>
+  </data>
+  <data name="tagCClass05" xml:space="preserve">
+    <value>Stormcaller</value>
+  </data>
+  <data name="tagCClass06" xml:space="preserve">
+    <value>Pyromancien</value>
+  </data>
+  <data name="tagCClass07" xml:space="preserve">
+    <value>Défenseur</value>
+  </data>
+  <data name="tagCClass08" xml:space="preserve">
+    <value>guerrier</value>
+  </data>
+  <data name="tagCClass09" xml:space="preserve">
+    <value>Briseur de sorts</value>
+  </data>
+  <data name="tagCClass10" xml:space="preserve">
+    <value>Champion</value>
+  </data>
+  <data name="tagCClass11" xml:space="preserve">
+    <value>Assassin</value>
+  </data>
+  <data name="tagCClass12" xml:space="preserve">
+    <value>Tueur</value>
+  </data>
+  <data name="tagCClass13" xml:space="preserve">
+    <value>Thane</value>
+  </data>
+  <data name="tagCClass14" xml:space="preserve">
+    <value>Battlemage</value>
+  </data>
+  <data name="tagCClass15" xml:space="preserve">
+    <value>Conquérant</value>
+  </data>
+  <data name="tagCClass16" xml:space="preserve">
+    <value>Relieur d'orthographe</value>
+  </data>
+  <data name="tagCClass17" xml:space="preserve">
+    <value>Gardien</value>
+  </data>
+  <data name="tagCClass18" xml:space="preserve">
+    <value>Corsaire</value>
+  </data>
+  <data name="tagCClass19" xml:space="preserve">
+    <value>Directeur</value>
+  </data>
+  <data name="tagCClass20" xml:space="preserve">
+    <value>Paladin</value>
+  </data>
+  <data name="tagCClass21" xml:space="preserve">
+    <value>Juggernaut</value>
+  </data>
+  <data name="tagCClass22" xml:space="preserve">
+    <value>Illusionniste</value>
+  </data>
+  <data name="tagCClass23" xml:space="preserve">
+    <value>Invocateur</value>
+  </data>
+  <data name="tagCClass24" xml:space="preserve">
+    <value>Magicien</value>
+  </data>
+  <data name="tagCClass25" xml:space="preserve">
+    <value>Vengeur</value>
+  </data>
+  <data name="tagCClass26" xml:space="preserve">
+    <value>Élémentaliste</value>
+  </data>
+  <data name="tagCClass27" xml:space="preserve">
+    <value>Oracle</value>
+  </data>
+  <data name="tagCClass28" xml:space="preserve">
+    <value>Druide</value>
+  </data>
+  <data name="tagCClass29" xml:space="preserve">
+    <value>Sorcier</value>
+  </data>
+  <data name="tagCClass30" xml:space="preserve">
+    <value>sauge</value>
+  </data>
+  <data name="tagCClass31" xml:space="preserve">
+    <value>Charmeur d'os</value>
+  </data>
+  <data name="tagCClass32" xml:space="preserve">
+    <value>Ranger</value>
+  </data>
+  <data name="tagCClass33" xml:space="preserve">
+    <value>Brigand</value>
+  </data>
+  <data name="tagCClass34" xml:space="preserve">
+    <value>démoniste</value>
+  </data>
+  <data name="tagCClass35" xml:space="preserve">
+    <value>Illusionniste</value>
+  </data>
+  <data name="tagCClass36" xml:space="preserve">
+    <value>Devin</value>
+  </data>
+  <data name="xtagCharacterClass01" xml:space="preserve">
+    <value>Voyant</value>
+  </data>
+  <data name="xtagCharacterClass02" xml:space="preserve">
+    <value>Présage</value>
+  </data>
+  <data name="xtagCharacterClass03" xml:space="preserve">
+    <value>Templier</value>
+  </data>
+  <data name="xtagCharacterClass04" xml:space="preserve">
+    <value>Evoker</value>
+  </data>
+  <data name="xtagCharacterClass05" xml:space="preserve">
+    <value>Prophète</value>
+  </data>
+  <data name="xtagCharacterClass06" xml:space="preserve">
+    <value>Haruspex</value>
+  </data>
+  <data name="xtagCharacterClass07" xml:space="preserve">
+    <value>Dreamkiller</value>
+  </data>
+  <data name="xtagCharacterClass08" xml:space="preserve">
+    <value>Ritualiste</value>
+  </data>
+  <data name="xtagCharacterClass09" xml:space="preserve">
+    <value>Devin</value>
+  </data>
+  <data name="x2tag_class_rm_rm" xml:space="preserve">
+    <value>Maître des runes</value>
+  </data>
+  <data name="x2tag_class_warfare_rm" xml:space="preserve">
+    <value>Berserker</value>
+  </data>
+  <data name="x2tag_class_defense_rm" xml:space="preserve">
+    <value>Runesmith</value>
+  </data>
+  <data name="x2tag_class_earth_rm" xml:space="preserve">
+    <value>Pierrespeaker</value>
+  </data>
+  <data name="x2tag_class_storm_rm" xml:space="preserve">
+    <value>Thunderer</value>
+  </data>
+  <data name="x2tag_class_hunting_rm" xml:space="preserve">
+    <value>Chasseur de dragon</value>
+  </data>
+  <data name="x2tag_class_stealth_rm" xml:space="preserve">
+    <value>Filou</value>
+  </data>
+  <data name="x2tag_class_nature_rm" xml:space="preserve">
+    <value>Skinchanger</value>
+  </data>
+  <data name="x2tag_class_spirit_rm" xml:space="preserve">
+    <value>Chaman</value>
+  </data>
+  <data name="x2tag_class_dream_rm" xml:space="preserve">
+    <value>Seidr Worker</value>
+  </data>
+  <data name="CurrentLevel" xml:space="preserve">
+    <value>Niveau</value>
+  </data>
+  <data name="Class" xml:space="preserve">
+    <value>Classe</value>
+  </data>
+  <data name="CurrentXP" xml:space="preserve">
+    <value>XP</value>
+  </data>
+  <data name="DifficultyUnlocked" xml:space="preserve">
+    <value>Difficulté</value>
+  </data>
+  <data name="Money" xml:space="preserve">
+    <value>Argent</value>
+  </data>
+  <data name="SkillPoints" xml:space="preserve">
+    <value>compétences</value>
+  </data>
+  <data name="AttributesPoints" xml:space="preserve">
+    <value>Points d'attributs</value>
+  </data>
+  <data name="BaseStrength" xml:space="preserve">
+    <value>Base Str</value>
+  </data>
+  <data name="BaseDexterity" xml:space="preserve">
+    <value>Base Dex</value>
+  </data>
+  <data name="BaseIntelligence" xml:space="preserve">
+    <value>Base Int</value>
+  </data>
+  <data name="BaseHealth" xml:space="preserve">
+    <value>Santé de base</value>
+  </data>
+  <data name="BaseMana" xml:space="preserve">
+    <value>Mana de base</value>
+  </data>
+  <data name="PlayTimeInSeconds" xml:space="preserve">
+    <value>Temps joué</value>
+  </data>
+  <data name="NumberOfDeaths" xml:space="preserve">
+    <value>Des morts</value>
+  </data>
+  <data name="NumberOfKills" xml:space="preserve">
+    <value>Tue</value>
+  </data>
+  <data name="ExperienceFromKills" xml:space="preserve">
+    <value>XP de Kills</value>
+  </data>
+  <data name="HealthPotionsUsed" xml:space="preserve">
+    <value>santé utilisés</value>
+  </data>
+  <data name="ManaPotionsUsed" xml:space="preserve">
+    <value>mana utilisés</value>
+  </data>
+  <data name="MaxLevel" xml:space="preserve">
+    <value>Niveau maximum</value>
+  </data>
+  <data name="NumHitsReceived" xml:space="preserve">
+    <value>Hits recv</value>
+  </data>
+  <data name="NumHitsInflicted" xml:space="preserve">
+    <value>Hits infligés</value>
+  </data>
+  <data name="GreatestDamageInflicted" xml:space="preserve">
+    <value>Plus grand Dmg</value>
+  </data>
+  <data name="GreatestMonster" xml:space="preserve">
+    <value>Plus grand mob</value>
+  </data>
+  <data name="CriticalHitsInflicted" xml:space="preserve">
+    <value>Coups critiques</value>
+  </data>
+  <data name="CriticalHitsReceived" xml:space="preserve">
+    <value>Coups critiques</value>
+  </data>
 </root>

--- a/src/TQVaultAE.Presentation/Resources.pl.resx
+++ b/src/TQVaultAE.Presentation/Resources.pl.resx
@@ -112,10 +112,10 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AboutDescription" xml:space="preserve">
     <value>TQVault od bman654 (wickedsoul_@yahoo.com) 
@@ -988,7 +988,6 @@ Oto złożony przykład: 'arktyczny &amp;mróz @miecz $pospolity | epicki'</valu
   <data name="GlobalRelicVaultStash" xml:space="preserve">
     <value>Reliktowa krypta</value>
   </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="SettingsAllowEditCE" xml:space="preserve">
     <value>Zezwalaj na funkcje edycji znaków</value>
   </data>
@@ -1015,9 +1014,6 @@ Oto złożony przykład: 'arktyczny &amp;mróz @miecz $pospolity | epicki'</valu
   </data>
   <data name="CEEnableLeveling" xml:space="preserve">
     <value>Włącz poziomowanie</value>
-  </data>
-  <data name="CEEnableRedistribute" xml:space="preserve">
-    <value>Włącz redystrybucję</value>
   </data>
   <data name="CEHealth" xml:space="preserve">
     <value>Zdrowie</value>
@@ -1046,87 +1042,244 @@ Oto złożony przykład: 'arktyczny &amp;mróz @miecz $pospolity | epicki'</valu
   <data name="CharacterEditBtn" xml:space="preserve">
     <value>Edytować</value>
   </data>
-
-  <data name="tagCClass01" xml:space="preserve"><value>Teurgista</value></data>
-  <data name="tagCClass02" xml:space="preserve"><value>Wędrowiec</value></data>
-  <data name="tagCClass03" xml:space="preserve"><value>Łobuz</value></data>
-  <data name="tagCClass04" xml:space="preserve"><value>Łowca</value></data>
-  <data name="tagCClass05" xml:space="preserve"><value>Stormcaller</value></data>
-  <data name="tagCClass06" xml:space="preserve"><value>Pyromancer</value></data>
-  <data name="tagCClass07" xml:space="preserve"><value>Obrońca</value></data>
-  <data name="tagCClass08" xml:space="preserve"><value>Wojownik</value></data>
-  <data name="tagCClass09" xml:space="preserve"><value>Łamacz zaklęć</value></data>
-  <data name="tagCClass10" xml:space="preserve"><value>Mistrz</value></data>
-  <data name="tagCClass11" xml:space="preserve"><value>Morderca</value></data>
-  <data name="tagCClass12" xml:space="preserve"><value>pogromca</value></data>
-  <data name="tagCClass13" xml:space="preserve"><value>Szlachcic angielski</value></data>
-  <data name="tagCClass14" xml:space="preserve"><value>Mag bitewny</value></data>
-  <data name="tagCClass15" xml:space="preserve"><value>Zdobywca</value></data>
-  <data name="tagCClass16" xml:space="preserve"><value>Spellbinder</value></data>
-  <data name="tagCClass17" xml:space="preserve"><value>Opiekun</value></data>
-  <data name="tagCClass18" xml:space="preserve"><value>Korsarz</value></data>
-  <data name="tagCClass19" xml:space="preserve"><value>Opiekun</value></data>
-  <data name="tagCClass20" xml:space="preserve"><value>Paladyn</value></data>
-  <data name="tagCClass21" xml:space="preserve"><value>Juggernaut</value></data>
-  <data name="tagCClass22" xml:space="preserve"><value>Magik</value></data>
-  <data name="tagCClass23" xml:space="preserve"><value>Przywoływacz</value></data>
-  <data name="tagCClass24" xml:space="preserve"><value>Magik</value></data>
-  <data name="tagCClass25" xml:space="preserve"><value>Mściciel</value></data>
-  <data name="tagCClass26" xml:space="preserve"><value>Elementalista</value></data>
-  <data name="tagCClass27" xml:space="preserve"><value>Wyrocznia</value></data>
-  <data name="tagCClass28" xml:space="preserve"><value>druid</value></data>
-  <data name="tagCClass29" xml:space="preserve"><value>Czarownik</value></data>
-  <data name="tagCClass30" xml:space="preserve"><value>szałwia</value></data>
-  <data name="tagCClass31" xml:space="preserve"><value>Zaklinacz kości</value></data>
-  <data name="tagCClass32" xml:space="preserve"><value>Leśniczy</value></data>
-  <data name="tagCClass33" xml:space="preserve"><value>Bandyta</value></data>
-  <data name="tagCClass34" xml:space="preserve"><value>Czarodziej</value></data>
-  <data name="tagCClass35" xml:space="preserve"><value>Iluzjonista</value></data>
-  <data name="tagCClass36" xml:space="preserve"><value>Wieszcz</value></data>
-  <data name="xtagCharacterClass01" xml:space="preserve"><value>Jasnowidz</value></data>
-  <data name="xtagCharacterClass02" xml:space="preserve"><value>Zwiastun</value></data>
-  <data name="xtagCharacterClass03" xml:space="preserve"><value>templariusz</value></data>
-  <data name="xtagCharacterClass04" xml:space="preserve"><value>Evoker</value></data>
-  <data name="xtagCharacterClass05" xml:space="preserve"><value>prorok</value></data>
-  <data name="xtagCharacterClass06" xml:space="preserve"><value>Haruspex</value></data>
-  <data name="xtagCharacterClass07" xml:space="preserve"><value>Dreamkiller</value></data>
-  <data name="xtagCharacterClass08" xml:space="preserve"><value>Rytualista</value></data>
-  <data name="xtagCharacterClass09" xml:space="preserve"><value>Wróżbita</value></data>
-  <data name="x2tag_class_rm_rm" xml:space="preserve"><value>Runemaster</value></data>
-  <data name="x2tag_class_warfare_rm" xml:space="preserve"><value>Berserker</value></data>
-  <data name="x2tag_class_defense_rm" xml:space="preserve"><value>Kowal Run</value></data>
-  <data name="x2tag_class_earth_rm" xml:space="preserve"><value>Stonespeaker</value></data>
-  <data name="x2tag_class_storm_rm" xml:space="preserve"><value>Grzmot</value></data>
-  <data name="x2tag_class_hunting_rm" xml:space="preserve"><value>Łowca smoków</value></data>
-  <data name="x2tag_class_stealth_rm" xml:space="preserve"><value>Oszust</value></data>
-  <data name="x2tag_class_nature_rm" xml:space="preserve"><value>Skinchanger</value></data>
-  <data name="x2tag_class_spirit_rm" xml:space="preserve"><value>Szaman</value></data>
-  <data name="x2tag_class_dream_rm" xml:space="preserve"><value>Pracownik Seidr</value></data>
-
-  <data name="CurrentLevel" xml:space="preserve"><value>Poziom</value></data>
-  <data name="Class" xml:space="preserve"><value>Klasa</value></data>
-  <data name="CurrentXP" xml:space="preserve"><value>XP</value></data>
-  <data name="DifficultyUnlocked" xml:space="preserve"><value>Trudność</value></data>
-  <data name="Money" xml:space="preserve"><value>pieniądze</value></data>
-  <data name="SkillPoints" xml:space="preserve"><value>umiejętności</value></data>
-  <data name="AttributesPoints" xml:space="preserve"><value>Punkty atrybutów</value></data>
-  <data name="BaseStrength" xml:space="preserve"><value>Ul</value></data>
-  <data name="BaseDexterity" xml:space="preserve"><value>Baza Dex</value></data>
-  <data name="BaseIntelligence" xml:space="preserve"><value>Baza Int</value></data>
-  <data name="BaseHealth" xml:space="preserve"><value>Zdrowie</value></data>
-  <data name="BaseMana" xml:space="preserve"><value>Baza Mana</value></data>
-  <data name="PlayTimeInSeconds" xml:space="preserve"><value>Czas grany</value></data>
-  <data name="NumberOfDeaths" xml:space="preserve"><value>Zgony</value></data>
-  <data name="NumberOfKills" xml:space="preserve"><value>Zabija</value></data>
-  <data name="ExperienceFromKills" xml:space="preserve"><value>XP from Kills</value></data>
-  <data name="HealthPotionsUsed" xml:space="preserve"><value>Garnki zdrowia</value></data>
-  <data name="ManaPotionsUsed" xml:space="preserve"><value>Garnki many</value></data>
-  <data name="MaxLevel" xml:space="preserve"><value>Najwyższy poziom</value></data>
-  <data name="NumHitsReceived" xml:space="preserve"><value>Hits Recv</value></data>
-  <data name="NumHitsInflicted" xml:space="preserve"><value>Zadane trafienia</value></data>
-  <data name="GreatestDamageInflicted" xml:space="preserve"><value>Największy Dmg</value></data>
-  <data name="GreatestMonster" xml:space="preserve"><value>Największy tłum</value></data>
-  <data name="CriticalHitsInflicted" xml:space="preserve"><value>krytyczne</value></data>
-  <data name="CriticalHitsReceived" xml:space="preserve"><value>krytyczne Recv</value></data>
-
+  <data name="tagCClass01" xml:space="preserve">
+    <value>Teurgista</value>
+  </data>
+  <data name="tagCClass02" xml:space="preserve">
+    <value>Wędrowiec</value>
+  </data>
+  <data name="tagCClass03" xml:space="preserve">
+    <value>Łobuz</value>
+  </data>
+  <data name="tagCClass04" xml:space="preserve">
+    <value>Łowca</value>
+  </data>
+  <data name="tagCClass05" xml:space="preserve">
+    <value>Stormcaller</value>
+  </data>
+  <data name="tagCClass06" xml:space="preserve">
+    <value>Pyromancer</value>
+  </data>
+  <data name="tagCClass07" xml:space="preserve">
+    <value>Obrońca</value>
+  </data>
+  <data name="tagCClass08" xml:space="preserve">
+    <value>Wojownik</value>
+  </data>
+  <data name="tagCClass09" xml:space="preserve">
+    <value>Łamacz zaklęć</value>
+  </data>
+  <data name="tagCClass10" xml:space="preserve">
+    <value>Mistrz</value>
+  </data>
+  <data name="tagCClass11" xml:space="preserve">
+    <value>Morderca</value>
+  </data>
+  <data name="tagCClass12" xml:space="preserve">
+    <value>pogromca</value>
+  </data>
+  <data name="tagCClass13" xml:space="preserve">
+    <value>Szlachcic angielski</value>
+  </data>
+  <data name="tagCClass14" xml:space="preserve">
+    <value>Mag bitewny</value>
+  </data>
+  <data name="tagCClass15" xml:space="preserve">
+    <value>Zdobywca</value>
+  </data>
+  <data name="tagCClass16" xml:space="preserve">
+    <value>Spellbinder</value>
+  </data>
+  <data name="tagCClass17" xml:space="preserve">
+    <value>Opiekun</value>
+  </data>
+  <data name="tagCClass18" xml:space="preserve">
+    <value>Korsarz</value>
+  </data>
+  <data name="tagCClass19" xml:space="preserve">
+    <value>Opiekun</value>
+  </data>
+  <data name="tagCClass20" xml:space="preserve">
+    <value>Paladyn</value>
+  </data>
+  <data name="tagCClass21" xml:space="preserve">
+    <value>Juggernaut</value>
+  </data>
+  <data name="tagCClass22" xml:space="preserve">
+    <value>Magik</value>
+  </data>
+  <data name="tagCClass23" xml:space="preserve">
+    <value>Przywoływacz</value>
+  </data>
+  <data name="tagCClass24" xml:space="preserve">
+    <value>Magik</value>
+  </data>
+  <data name="tagCClass25" xml:space="preserve">
+    <value>Mściciel</value>
+  </data>
+  <data name="tagCClass26" xml:space="preserve">
+    <value>Elementalista</value>
+  </data>
+  <data name="tagCClass27" xml:space="preserve">
+    <value>Wyrocznia</value>
+  </data>
+  <data name="tagCClass28" xml:space="preserve">
+    <value>druid</value>
+  </data>
+  <data name="tagCClass29" xml:space="preserve">
+    <value>Czarownik</value>
+  </data>
+  <data name="tagCClass30" xml:space="preserve">
+    <value>szałwia</value>
+  </data>
+  <data name="tagCClass31" xml:space="preserve">
+    <value>Zaklinacz kości</value>
+  </data>
+  <data name="tagCClass32" xml:space="preserve">
+    <value>Leśniczy</value>
+  </data>
+  <data name="tagCClass33" xml:space="preserve">
+    <value>Bandyta</value>
+  </data>
+  <data name="tagCClass34" xml:space="preserve">
+    <value>Czarodziej</value>
+  </data>
+  <data name="tagCClass35" xml:space="preserve">
+    <value>Iluzjonista</value>
+  </data>
+  <data name="tagCClass36" xml:space="preserve">
+    <value>Wieszcz</value>
+  </data>
+  <data name="xtagCharacterClass01" xml:space="preserve">
+    <value>Jasnowidz</value>
+  </data>
+  <data name="xtagCharacterClass02" xml:space="preserve">
+    <value>Zwiastun</value>
+  </data>
+  <data name="xtagCharacterClass03" xml:space="preserve">
+    <value>templariusz</value>
+  </data>
+  <data name="xtagCharacterClass04" xml:space="preserve">
+    <value>Evoker</value>
+  </data>
+  <data name="xtagCharacterClass05" xml:space="preserve">
+    <value>prorok</value>
+  </data>
+  <data name="xtagCharacterClass06" xml:space="preserve">
+    <value>Haruspex</value>
+  </data>
+  <data name="xtagCharacterClass07" xml:space="preserve">
+    <value>Dreamkiller</value>
+  </data>
+  <data name="xtagCharacterClass08" xml:space="preserve">
+    <value>Rytualista</value>
+  </data>
+  <data name="xtagCharacterClass09" xml:space="preserve">
+    <value>Wróżbita</value>
+  </data>
+  <data name="x2tag_class_rm_rm" xml:space="preserve">
+    <value>Runemaster</value>
+  </data>
+  <data name="x2tag_class_warfare_rm" xml:space="preserve">
+    <value>Berserker</value>
+  </data>
+  <data name="x2tag_class_defense_rm" xml:space="preserve">
+    <value>Kowal Run</value>
+  </data>
+  <data name="x2tag_class_earth_rm" xml:space="preserve">
+    <value>Stonespeaker</value>
+  </data>
+  <data name="x2tag_class_storm_rm" xml:space="preserve">
+    <value>Grzmot</value>
+  </data>
+  <data name="x2tag_class_hunting_rm" xml:space="preserve">
+    <value>Łowca smoków</value>
+  </data>
+  <data name="x2tag_class_stealth_rm" xml:space="preserve">
+    <value>Oszust</value>
+  </data>
+  <data name="x2tag_class_nature_rm" xml:space="preserve">
+    <value>Skinchanger</value>
+  </data>
+  <data name="x2tag_class_spirit_rm" xml:space="preserve">
+    <value>Szaman</value>
+  </data>
+  <data name="x2tag_class_dream_rm" xml:space="preserve">
+    <value>Pracownik Seidr</value>
+  </data>
+  <data name="CurrentLevel" xml:space="preserve">
+    <value>Poziom</value>
+  </data>
+  <data name="Class" xml:space="preserve">
+    <value>Klasa</value>
+  </data>
+  <data name="CurrentXP" xml:space="preserve">
+    <value>XP</value>
+  </data>
+  <data name="DifficultyUnlocked" xml:space="preserve">
+    <value>Trudność</value>
+  </data>
+  <data name="Money" xml:space="preserve">
+    <value>pieniądze</value>
+  </data>
+  <data name="SkillPoints" xml:space="preserve">
+    <value>umiejętności</value>
+  </data>
+  <data name="AttributesPoints" xml:space="preserve">
+    <value>Punkty atrybutów</value>
+  </data>
+  <data name="BaseStrength" xml:space="preserve">
+    <value>Ul</value>
+  </data>
+  <data name="BaseDexterity" xml:space="preserve">
+    <value>Baza Dex</value>
+  </data>
+  <data name="BaseIntelligence" xml:space="preserve">
+    <value>Baza Int</value>
+  </data>
+  <data name="BaseHealth" xml:space="preserve">
+    <value>Zdrowie</value>
+  </data>
+  <data name="BaseMana" xml:space="preserve">
+    <value>Baza Mana</value>
+  </data>
+  <data name="PlayTimeInSeconds" xml:space="preserve">
+    <value>Czas grany</value>
+  </data>
+  <data name="NumberOfDeaths" xml:space="preserve">
+    <value>Zgony</value>
+  </data>
+  <data name="NumberOfKills" xml:space="preserve">
+    <value>Zabija</value>
+  </data>
+  <data name="ExperienceFromKills" xml:space="preserve">
+    <value>XP from Kills</value>
+  </data>
+  <data name="HealthPotionsUsed" xml:space="preserve">
+    <value>Garnki zdrowia</value>
+  </data>
+  <data name="ManaPotionsUsed" xml:space="preserve">
+    <value>Garnki many</value>
+  </data>
+  <data name="MaxLevel" xml:space="preserve">
+    <value>Najwyższy poziom</value>
+  </data>
+  <data name="NumHitsReceived" xml:space="preserve">
+    <value>Hits Recv</value>
+  </data>
+  <data name="NumHitsInflicted" xml:space="preserve">
+    <value>Zadane trafienia</value>
+  </data>
+  <data name="GreatestDamageInflicted" xml:space="preserve">
+    <value>Największy Dmg</value>
+  </data>
+  <data name="GreatestMonster" xml:space="preserve">
+    <value>Największy tłum</value>
+  </data>
+  <data name="CriticalHitsInflicted" xml:space="preserve">
+    <value>krytyczne</value>
+  </data>
+  <data name="CriticalHitsReceived" xml:space="preserve">
+    <value>krytyczne Recv</value>
+  </data>
 </root>

--- a/src/TQVaultAE.Presentation/Resources.resx
+++ b/src/TQVaultAE.Presentation/Resources.resx
@@ -1217,9 +1217,6 @@ Here is a complex example: 'arctic &amp; of frost @ring $rare | common'</value>
   <data name="CEEnableLeveling" xml:space="preserve">
     <value>Enable Leveling</value>
   </data>
-  <data name="CEEnableRedistribute" xml:space="preserve">
-    <value>Enable Redistribute</value>
-  </data>
   <data name="CEHealth" xml:space="preserve">
     <value>Health</value>
   </data>
@@ -1247,86 +1244,244 @@ Here is a complex example: 'arctic &amp; of frost @ring $rare | common'</value>
   <data name="CharacterEditBtn" xml:space="preserve">
     <value>Edit</value>
   </data>
-  
-  <data name="tagCClass01" xml:space="preserve"><value>Theurgist</value></data>
-  <data name="tagCClass02" xml:space="preserve"><value>Wanderer</value></data>
-  <data name="tagCClass03" xml:space="preserve"><value>Rogue</value></data>
-  <data name="tagCClass04" xml:space="preserve"><value>Hunter</value></data>
-  <data name="tagCClass05" xml:space="preserve"><value>Stormcaller</value></data>
-  <data name="tagCClass06" xml:space="preserve"><value>Pyromancer</value></data>
-  <data name="tagCClass07" xml:space="preserve"><value>Defender</value></data>
-  <data name="tagCClass08" xml:space="preserve"><value>Warrior</value></data>
-  <data name="tagCClass09" xml:space="preserve"><value>Spellbreaker</value></data>
-  <data name="tagCClass10" xml:space="preserve"><value>Champion</value></data>
-  <data name="tagCClass11" xml:space="preserve"><value>Assassin</value></data>
-  <data name="tagCClass12" xml:space="preserve"><value>Slayer</value></data>
-  <data name="tagCClass13" xml:space="preserve"><value>Thane</value></data>
-  <data name="tagCClass14" xml:space="preserve"><value>Battlemage</value></data>
-  <data name="tagCClass15" xml:space="preserve"><value>Conqueror</value></data>
-  <data name="tagCClass16" xml:space="preserve"><value>Spellbinder</value></data>
-  <data name="tagCClass17" xml:space="preserve"><value>Guardian</value></data>
-  <data name="tagCClass18" xml:space="preserve"><value>Corsair</value></data>
-  <data name="tagCClass19" xml:space="preserve"><value>Warden</value></data>
-  <data name="tagCClass20" xml:space="preserve"><value>Paladin</value></data>
-  <data name="tagCClass21" xml:space="preserve"><value>Juggernaut</value></data>
-  <data name="tagCClass22" xml:space="preserve"><value>Conjurer</value></data>
-  <data name="tagCClass23" xml:space="preserve"><value>Summoner</value></data>
-  <data name="tagCClass24" xml:space="preserve"><value>Magician</value></data>
-  <data name="tagCClass25" xml:space="preserve"><value>Avenger</value></data>
-  <data name="tagCClass26" xml:space="preserve"><value>Elementalist</value></data>
-  <data name="tagCClass27" xml:space="preserve"><value>Oracle</value></data>
-  <data name="tagCClass28" xml:space="preserve"><value>Druid</value></data>
-  <data name="tagCClass29" xml:space="preserve"><value>Sorcerer</value></data>
-  <data name="tagCClass30" xml:space="preserve"><value>Sage</value></data>
-  <data name="tagCClass31" xml:space="preserve"><value>Bone Charmer</value></data>
-  <data name="tagCClass32" xml:space="preserve"><value>Ranger</value></data>
-  <data name="tagCClass33" xml:space="preserve"><value>Brigand</value></data>
-  <data name="tagCClass34" xml:space="preserve"><value>Warlock</value></data>
-  <data name="tagCClass35" xml:space="preserve"><value>Illusionist</value></data>
-  <data name="tagCClass36" xml:space="preserve"><value>Soothsayer</value></data>
-  <data name="xtagCharacterClass01" xml:space="preserve"><value>Seer</value></data>
-  <data name="xtagCharacterClass02" xml:space="preserve"><value>Harbinger</value></data>
-  <data name="xtagCharacterClass03" xml:space="preserve"><value>Templar</value></data>
-  <data name="xtagCharacterClass04" xml:space="preserve"><value>Evoker</value></data>
-  <data name="xtagCharacterClass05" xml:space="preserve"><value>Prophet</value></data>
-  <data name="xtagCharacterClass06" xml:space="preserve"><value>Haruspex</value></data>
-  <data name="xtagCharacterClass07" xml:space="preserve"><value>Dreamkiller</value></data>
-  <data name="xtagCharacterClass08" xml:space="preserve"><value>Ritualist</value></data>
-  <data name="xtagCharacterClass09" xml:space="preserve"><value>Diviner</value></data>
-  <data name="x2tag_class_rm_rm" xml:space="preserve"><value>Runemaster</value></data>
-  <data name="x2tag_class_warfare_rm" xml:space="preserve"><value>Berserker</value></data>
-  <data name="x2tag_class_defense_rm" xml:space="preserve"><value>Runesmith</value></data>
-  <data name="x2tag_class_earth_rm" xml:space="preserve"><value>Stonespeaker</value></data>
-  <data name="x2tag_class_storm_rm" xml:space="preserve"><value>Thunderer</value></data>
-  <data name="x2tag_class_hunting_rm" xml:space="preserve"><value>Dragon Hunter</value></data>
-  <data name="x2tag_class_stealth_rm" xml:space="preserve"><value>Trickster</value></data>
-  <data name="x2tag_class_nature_rm" xml:space="preserve"><value>Skinchanger</value></data>
-  <data name="x2tag_class_spirit_rm" xml:space="preserve"><value>Shaman</value></data>
-  <data name="x2tag_class_dream_rm" xml:space="preserve"><value>Seidr Worker</value></data>
-
-  <data name="CurrentLevel" xml:space="preserve"><value>Level</value></data>
-  <data name="Class" xml:space="preserve"><value>Class</value></data>
-  <data name="CurrentXP" xml:space="preserve"><value>XP</value></data>
-  <data name="DifficultyUnlocked" xml:space="preserve"><value>Difficulty</value></data>
-  <data name="Money" xml:space="preserve"><value>Money</value></data>
-  <data name="SkillPoints" xml:space="preserve"><value>Skill Points</value></data>
-  <data name="AttributesPoints" xml:space="preserve"><value>Attribute Points</value></data>
-  <data name="BaseStrength" xml:space="preserve"><value>Base Str</value></data>
-  <data name="BaseDexterity" xml:space="preserve"><value>Base Dex</value></data>
-  <data name="BaseIntelligence" xml:space="preserve"><value>Base Int</value></data>
-  <data name="BaseHealth" xml:space="preserve"><value>Base Health</value></data>
-  <data name="BaseMana" xml:space="preserve"><value>Base Mana</value></data>
-  <data name="PlayTimeInSeconds" xml:space="preserve"><value>Time Played</value></data>
-  <data name="NumberOfDeaths" xml:space="preserve"><value>Deaths</value></data>
-  <data name="NumberOfKills" xml:space="preserve"><value>Kills</value></data>
-  <data name="ExperienceFromKills" xml:space="preserve"><value>XP From Kills</value></data>
-  <data name="HealthPotionsUsed" xml:space="preserve"><value>Health Pots Used</value></data>
-  <data name="ManaPotionsUsed" xml:space="preserve"><value>Mana Pots Used</value></data>
-  <data name="MaxLevel" xml:space="preserve"><value>Max Level</value></data>
-  <data name="NumHitsReceived" xml:space="preserve"><value>Hits Recv</value></data>
-  <data name="NumHitsInflicted" xml:space="preserve"><value>Hits Inflicted</value></data>
-  <data name="GreatestDamageInflicted" xml:space="preserve"><value>Greatest Dmg</value></data>
-  <data name="GreatestMonster" xml:space="preserve"><value>Greatest Mob</value></data>
-  <data name="CriticalHitsInflicted" xml:space="preserve"><value>Critical Hits</value></data>
-  <data name="CriticalHitsReceived" xml:space="preserve"><value>Critical Hits Recv</value></data>
+  <data name="tagCClass01" xml:space="preserve">
+    <value>Theurgist</value>
+  </data>
+  <data name="tagCClass02" xml:space="preserve">
+    <value>Wanderer</value>
+  </data>
+  <data name="tagCClass03" xml:space="preserve">
+    <value>Rogue</value>
+  </data>
+  <data name="tagCClass04" xml:space="preserve">
+    <value>Hunter</value>
+  </data>
+  <data name="tagCClass05" xml:space="preserve">
+    <value>Stormcaller</value>
+  </data>
+  <data name="tagCClass06" xml:space="preserve">
+    <value>Pyromancer</value>
+  </data>
+  <data name="tagCClass07" xml:space="preserve">
+    <value>Defender</value>
+  </data>
+  <data name="tagCClass08" xml:space="preserve">
+    <value>Warrior</value>
+  </data>
+  <data name="tagCClass09" xml:space="preserve">
+    <value>Spellbreaker</value>
+  </data>
+  <data name="tagCClass10" xml:space="preserve">
+    <value>Champion</value>
+  </data>
+  <data name="tagCClass11" xml:space="preserve">
+    <value>Assassin</value>
+  </data>
+  <data name="tagCClass12" xml:space="preserve">
+    <value>Slayer</value>
+  </data>
+  <data name="tagCClass13" xml:space="preserve">
+    <value>Thane</value>
+  </data>
+  <data name="tagCClass14" xml:space="preserve">
+    <value>Battlemage</value>
+  </data>
+  <data name="tagCClass15" xml:space="preserve">
+    <value>Conqueror</value>
+  </data>
+  <data name="tagCClass16" xml:space="preserve">
+    <value>Spellbinder</value>
+  </data>
+  <data name="tagCClass17" xml:space="preserve">
+    <value>Guardian</value>
+  </data>
+  <data name="tagCClass18" xml:space="preserve">
+    <value>Corsair</value>
+  </data>
+  <data name="tagCClass19" xml:space="preserve">
+    <value>Warden</value>
+  </data>
+  <data name="tagCClass20" xml:space="preserve">
+    <value>Paladin</value>
+  </data>
+  <data name="tagCClass21" xml:space="preserve">
+    <value>Juggernaut</value>
+  </data>
+  <data name="tagCClass22" xml:space="preserve">
+    <value>Conjurer</value>
+  </data>
+  <data name="tagCClass23" xml:space="preserve">
+    <value>Summoner</value>
+  </data>
+  <data name="tagCClass24" xml:space="preserve">
+    <value>Magician</value>
+  </data>
+  <data name="tagCClass25" xml:space="preserve">
+    <value>Avenger</value>
+  </data>
+  <data name="tagCClass26" xml:space="preserve">
+    <value>Elementalist</value>
+  </data>
+  <data name="tagCClass27" xml:space="preserve">
+    <value>Oracle</value>
+  </data>
+  <data name="tagCClass28" xml:space="preserve">
+    <value>Druid</value>
+  </data>
+  <data name="tagCClass29" xml:space="preserve">
+    <value>Sorcerer</value>
+  </data>
+  <data name="tagCClass30" xml:space="preserve">
+    <value>Sage</value>
+  </data>
+  <data name="tagCClass31" xml:space="preserve">
+    <value>Bone Charmer</value>
+  </data>
+  <data name="tagCClass32" xml:space="preserve">
+    <value>Ranger</value>
+  </data>
+  <data name="tagCClass33" xml:space="preserve">
+    <value>Brigand</value>
+  </data>
+  <data name="tagCClass34" xml:space="preserve">
+    <value>Warlock</value>
+  </data>
+  <data name="tagCClass35" xml:space="preserve">
+    <value>Illusionist</value>
+  </data>
+  <data name="tagCClass36" xml:space="preserve">
+    <value>Soothsayer</value>
+  </data>
+  <data name="xtagCharacterClass01" xml:space="preserve">
+    <value>Seer</value>
+  </data>
+  <data name="xtagCharacterClass02" xml:space="preserve">
+    <value>Harbinger</value>
+  </data>
+  <data name="xtagCharacterClass03" xml:space="preserve">
+    <value>Templar</value>
+  </data>
+  <data name="xtagCharacterClass04" xml:space="preserve">
+    <value>Evoker</value>
+  </data>
+  <data name="xtagCharacterClass05" xml:space="preserve">
+    <value>Prophet</value>
+  </data>
+  <data name="xtagCharacterClass06" xml:space="preserve">
+    <value>Haruspex</value>
+  </data>
+  <data name="xtagCharacterClass07" xml:space="preserve">
+    <value>Dreamkiller</value>
+  </data>
+  <data name="xtagCharacterClass08" xml:space="preserve">
+    <value>Ritualist</value>
+  </data>
+  <data name="xtagCharacterClass09" xml:space="preserve">
+    <value>Diviner</value>
+  </data>
+  <data name="x2tag_class_rm_rm" xml:space="preserve">
+    <value>Runemaster</value>
+  </data>
+  <data name="x2tag_class_warfare_rm" xml:space="preserve">
+    <value>Berserker</value>
+  </data>
+  <data name="x2tag_class_defense_rm" xml:space="preserve">
+    <value>Runesmith</value>
+  </data>
+  <data name="x2tag_class_earth_rm" xml:space="preserve">
+    <value>Stonespeaker</value>
+  </data>
+  <data name="x2tag_class_storm_rm" xml:space="preserve">
+    <value>Thunderer</value>
+  </data>
+  <data name="x2tag_class_hunting_rm" xml:space="preserve">
+    <value>Dragon Hunter</value>
+  </data>
+  <data name="x2tag_class_stealth_rm" xml:space="preserve">
+    <value>Trickster</value>
+  </data>
+  <data name="x2tag_class_nature_rm" xml:space="preserve">
+    <value>Skinchanger</value>
+  </data>
+  <data name="x2tag_class_spirit_rm" xml:space="preserve">
+    <value>Shaman</value>
+  </data>
+  <data name="x2tag_class_dream_rm" xml:space="preserve">
+    <value>Seidr Worker</value>
+  </data>
+  <data name="CurrentLevel" xml:space="preserve">
+    <value>Level</value>
+  </data>
+  <data name="Class" xml:space="preserve">
+    <value>Class</value>
+  </data>
+  <data name="CurrentXP" xml:space="preserve">
+    <value>XP</value>
+  </data>
+  <data name="DifficultyUnlocked" xml:space="preserve">
+    <value>Difficulty</value>
+  </data>
+  <data name="Money" xml:space="preserve">
+    <value>Money</value>
+  </data>
+  <data name="SkillPoints" xml:space="preserve">
+    <value>Skill Points</value>
+  </data>
+  <data name="AttributesPoints" xml:space="preserve">
+    <value>Attribute Points</value>
+  </data>
+  <data name="BaseStrength" xml:space="preserve">
+    <value>Base Str</value>
+  </data>
+  <data name="BaseDexterity" xml:space="preserve">
+    <value>Base Dex</value>
+  </data>
+  <data name="BaseIntelligence" xml:space="preserve">
+    <value>Base Int</value>
+  </data>
+  <data name="BaseHealth" xml:space="preserve">
+    <value>Base Health</value>
+  </data>
+  <data name="BaseMana" xml:space="preserve">
+    <value>Base Mana</value>
+  </data>
+  <data name="PlayTimeInSeconds" xml:space="preserve">
+    <value>Time Played</value>
+  </data>
+  <data name="NumberOfDeaths" xml:space="preserve">
+    <value>Deaths</value>
+  </data>
+  <data name="NumberOfKills" xml:space="preserve">
+    <value>Kills</value>
+  </data>
+  <data name="ExperienceFromKills" xml:space="preserve">
+    <value>XP From Kills</value>
+  </data>
+  <data name="HealthPotionsUsed" xml:space="preserve">
+    <value>Health Pots Used</value>
+  </data>
+  <data name="ManaPotionsUsed" xml:space="preserve">
+    <value>Mana Pots Used</value>
+  </data>
+  <data name="MaxLevel" xml:space="preserve">
+    <value>Max Level</value>
+  </data>
+  <data name="NumHitsReceived" xml:space="preserve">
+    <value>Hits Recv</value>
+  </data>
+  <data name="NumHitsInflicted" xml:space="preserve">
+    <value>Hits Inflicted</value>
+  </data>
+  <data name="GreatestDamageInflicted" xml:space="preserve">
+    <value>Greatest Dmg</value>
+  </data>
+  <data name="GreatestMonster" xml:space="preserve">
+    <value>Greatest Mob</value>
+  </data>
+  <data name="CriticalHitsInflicted" xml:space="preserve">
+    <value>Critical Hits</value>
+  </data>
+  <data name="CriticalHitsReceived" xml:space="preserve">
+    <value>Critical Hits Recv</value>
+  </data>
 </root>

--- a/src/TQVaultAE.Presentation/Resources.ru.resx
+++ b/src/TQVaultAE.Presentation/Resources.ru.resx
@@ -112,10 +112,10 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AboutDescription" xml:space="preserve">
     <value>TQVault by bman654 (wickedsoul_@yahoo.com) 
@@ -995,7 +995,6 @@ Would you like to disable loading all files?</value>
   <data name="GlobalRelicVaultStash" xml:space="preserve">
     <value>реликвия Свод</value>
   </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="SettingsAllowEditCE" xml:space="preserve">
     <value>Разрешить функции редактирования символов</value>
   </data>
@@ -1022,9 +1021,6 @@ Would you like to disable loading all files?</value>
   </data>
   <data name="CEEnableLeveling" xml:space="preserve">
     <value>Включить выравнивание</value>
-  </data>
-  <data name="CEEnableRedistribute" xml:space="preserve">
-    <value>Включить перераспределение</value>
   </data>
   <data name="CEHealth" xml:space="preserve">
     <value>Здоровье</value>
@@ -1053,87 +1049,244 @@ Would you like to disable loading all files?</value>
   <data name="CharacterEditBtn" xml:space="preserve">
     <value>монтировать</value>
   </data>
-
-  <data name="tagCClass01" xml:space="preserve"><value>маг</value></data>
-  <data name="tagCClass02" xml:space="preserve"><value>странник</value></data>
-  <data name="tagCClass03" xml:space="preserve"><value>мошенник</value></data>
-  <data name="tagCClass04" xml:space="preserve"><value>охотник</value></data>
-  <data name="tagCClass05" xml:space="preserve"><value>Буревестник</value></data>
-  <data name="tagCClass06" xml:space="preserve"><value>Пиротехник</value></data>
-  <data name="tagCClass07" xml:space="preserve"><value>Защитник</value></data>
-  <data name="tagCClass08" xml:space="preserve"><value>воин</value></data>
-  <data name="tagCClass09" xml:space="preserve"><value>Spellbreaker</value></data>
-  <data name="tagCClass10" xml:space="preserve"><value>чемпион</value></data>
-  <data name="tagCClass11" xml:space="preserve"><value>убийца</value></data>
-  <data name="tagCClass12" xml:space="preserve"><value>убийца</value></data>
-  <data name="tagCClass13" xml:space="preserve"><value>тан</value></data>
-  <data name="tagCClass14" xml:space="preserve"><value>Battlemage</value></data>
-  <data name="tagCClass15" xml:space="preserve"><value>завоеватель</value></data>
-  <data name="tagCClass16" xml:space="preserve"><value>оратор</value></data>
-  <data name="tagCClass17" xml:space="preserve"><value>блюститель</value></data>
-  <data name="tagCClass18" xml:space="preserve"><value>корсар</value></data>
-  <data name="tagCClass19" xml:space="preserve"><value>смотритель</value></data>
-  <data name="tagCClass20" xml:space="preserve"><value>паладин</value></data>
-  <data name="tagCClass21" xml:space="preserve"><value>Джаггернаут</value></data>
-  <data name="tagCClass22" xml:space="preserve"><value>фокусник</value></data>
-  <data name="tagCClass23" xml:space="preserve"><value>Summoner</value></data>
-  <data name="tagCClass24" xml:space="preserve"><value>фокусник</value></data>
-  <data name="tagCClass25" xml:space="preserve"><value>Мститель</value></data>
-  <data name="tagCClass26" xml:space="preserve"><value>Elementalist</value></data>
-  <data name="tagCClass27" xml:space="preserve"><value>оракул</value></data>
-  <data name="tagCClass28" xml:space="preserve"><value>друид</value></data>
-  <data name="tagCClass29" xml:space="preserve"><value>Колдун</value></data>
-  <data name="tagCClass30" xml:space="preserve"><value>шалфей</value></data>
-  <data name="tagCClass31" xml:space="preserve"><value>Заклинатель костей</value></data>
-  <data name="tagCClass32" xml:space="preserve"><value>рейнджер</value></data>
-  <data name="tagCClass33" xml:space="preserve"><value>разбойник</value></data>
-  <data name="tagCClass34" xml:space="preserve"><value>Чернокнижник</value></data>
-  <data name="tagCClass35" xml:space="preserve"><value>иллюзионист</value></data>
-  <data name="tagCClass36" xml:space="preserve"><value>предсказатель</value></data>
-  <data name="xtagCharacterClass01" xml:space="preserve"><value>провидец</value></data>
-  <data name="xtagCharacterClass02" xml:space="preserve"><value>предвестник</value></data>
-  <data name="xtagCharacterClass03" xml:space="preserve"><value>тамплиер</value></data>
-  <data name="xtagCharacterClass04" xml:space="preserve"><value>пробудителя</value></data>
-  <data name="xtagCharacterClass05" xml:space="preserve"><value>пророк</value></data>
-  <data name="xtagCharacterClass06" xml:space="preserve"><value>гаруспика</value></data>
-  <data name="xtagCharacterClass07" xml:space="preserve"><value>Dreamkiller</value></data>
-  <data name="xtagCharacterClass08" xml:space="preserve"><value>приверженец обрядности</value></data>
-  <data name="xtagCharacterClass09" xml:space="preserve"><value>предсказатель</value></data>
-  <data name="x2tag_class_rm_rm" xml:space="preserve"><value>mрун</value></data>
-  <data name="x2tag_class_warfare_rm" xml:space="preserve"><value>берсерк</value></data>
-  <data name="x2tag_class_defense_rm" xml:space="preserve"><value>Runesmith</value></data>
-  <data name="x2tag_class_earth_rm" xml:space="preserve"><value>Stonespeaker</value></data>
-  <data name="x2tag_class_storm_rm" xml:space="preserve"><value>Thгромовержец</value></data>
-  <data name="x2tag_class_hunting_rm" xml:space="preserve"><value>Охотник на драконов</value></data>
-  <data name="x2tag_class_stealth_rm" xml:space="preserve"><value>обманщик</value></data>
-  <data name="x2tag_class_nature_rm" xml:space="preserve"><value>Skinchanger</value></data>
-  <data name="x2tag_class_spirit_rm" xml:space="preserve"><value>шаман</value></data>
-  <data name="x2tag_class_dream_rm" xml:space="preserve"><value>Seidr Worker</value></data>
-
-  <data name="CurrentLevel" xml:space="preserve"><value>уровень</value></data>
-  <data name="Class" xml:space="preserve"><value>Учебный класс</value></data>
-  <data name="CurrentXP" xml:space="preserve"><value>XP</value></data>
-  <data name="DifficultyUnlocked" xml:space="preserve"><value>трудность</value></data>
-  <data name="Money" xml:space="preserve"><value>Деньги</value></data>
-  <data name="SkillPoints" xml:space="preserve"><value>Очки навыка</value></data>
-  <data name="AttributesPoints" xml:space="preserve"><value>Атрибуты</value></data>
-  <data name="BaseStrength" xml:space="preserve"><value>База ул</value></data>
-  <data name="BaseDexterity" xml:space="preserve"><value>Base Dex</value></data>
-  <data name="BaseIntelligence" xml:space="preserve"><value>Base Int</value></data>
-  <data name="BaseHealth" xml:space="preserve"><value>Базовое здоровье</value></data>
-  <data name="BaseMana" xml:space="preserve"><value>Базовая мана</value></data>
-  <data name="PlayTimeInSeconds" xml:space="preserve"><value>Время в игре</value></data>
-  <data name="NumberOfDeaths" xml:space="preserve"><value>Смертей</value></data>
-  <data name="NumberOfKills" xml:space="preserve"><value>Убийства</value></data>
-  <data name="ExperienceFromKills" xml:space="preserve"><value>XP от убийств</value></data>
-  <data name="HealthPotionsUsed" xml:space="preserve"><value>Зелья здоровья</value></data>
-  <data name="ManaPotionsUsed" xml:space="preserve"><value>Кастрюли маны</value></data>
-  <data name="MaxLevel" xml:space="preserve"><value>Максимальный уровень</value></data>
-  <data name="NumHitsReceived" xml:space="preserve"><value>Хиты Recv</value></data>
-  <data name="NumHitsInflicted" xml:space="preserve"><value>Хиты нанесены</value></data>
-  <data name="GreatestDamageInflicted" xml:space="preserve"><value>Величайший урон</value></data>
-  <data name="GreatestMonster" xml:space="preserve"><value>Величайшая Моб</value></data>
-  <data name="CriticalHitsInflicted" xml:space="preserve"><value>Критические Хиты</value></data>
-  <data name="CriticalHitsReceived" xml:space="preserve"><value>Критики приняты</value></data>
-
+  <data name="tagCClass01" xml:space="preserve">
+    <value>маг</value>
+  </data>
+  <data name="tagCClass02" xml:space="preserve">
+    <value>странник</value>
+  </data>
+  <data name="tagCClass03" xml:space="preserve">
+    <value>мошенник</value>
+  </data>
+  <data name="tagCClass04" xml:space="preserve">
+    <value>охотник</value>
+  </data>
+  <data name="tagCClass05" xml:space="preserve">
+    <value>Буревестник</value>
+  </data>
+  <data name="tagCClass06" xml:space="preserve">
+    <value>Пиротехник</value>
+  </data>
+  <data name="tagCClass07" xml:space="preserve">
+    <value>Защитник</value>
+  </data>
+  <data name="tagCClass08" xml:space="preserve">
+    <value>воин</value>
+  </data>
+  <data name="tagCClass09" xml:space="preserve">
+    <value>Spellbreaker</value>
+  </data>
+  <data name="tagCClass10" xml:space="preserve">
+    <value>чемпион</value>
+  </data>
+  <data name="tagCClass11" xml:space="preserve">
+    <value>убийца</value>
+  </data>
+  <data name="tagCClass12" xml:space="preserve">
+    <value>убийца</value>
+  </data>
+  <data name="tagCClass13" xml:space="preserve">
+    <value>тан</value>
+  </data>
+  <data name="tagCClass14" xml:space="preserve">
+    <value>Battlemage</value>
+  </data>
+  <data name="tagCClass15" xml:space="preserve">
+    <value>завоеватель</value>
+  </data>
+  <data name="tagCClass16" xml:space="preserve">
+    <value>оратор</value>
+  </data>
+  <data name="tagCClass17" xml:space="preserve">
+    <value>блюститель</value>
+  </data>
+  <data name="tagCClass18" xml:space="preserve">
+    <value>корсар</value>
+  </data>
+  <data name="tagCClass19" xml:space="preserve">
+    <value>смотритель</value>
+  </data>
+  <data name="tagCClass20" xml:space="preserve">
+    <value>паладин</value>
+  </data>
+  <data name="tagCClass21" xml:space="preserve">
+    <value>Джаггернаут</value>
+  </data>
+  <data name="tagCClass22" xml:space="preserve">
+    <value>фокусник</value>
+  </data>
+  <data name="tagCClass23" xml:space="preserve">
+    <value>Summoner</value>
+  </data>
+  <data name="tagCClass24" xml:space="preserve">
+    <value>фокусник</value>
+  </data>
+  <data name="tagCClass25" xml:space="preserve">
+    <value>Мститель</value>
+  </data>
+  <data name="tagCClass26" xml:space="preserve">
+    <value>Elementalist</value>
+  </data>
+  <data name="tagCClass27" xml:space="preserve">
+    <value>оракул</value>
+  </data>
+  <data name="tagCClass28" xml:space="preserve">
+    <value>друид</value>
+  </data>
+  <data name="tagCClass29" xml:space="preserve">
+    <value>Колдун</value>
+  </data>
+  <data name="tagCClass30" xml:space="preserve">
+    <value>шалфей</value>
+  </data>
+  <data name="tagCClass31" xml:space="preserve">
+    <value>Заклинатель костей</value>
+  </data>
+  <data name="tagCClass32" xml:space="preserve">
+    <value>рейнджер</value>
+  </data>
+  <data name="tagCClass33" xml:space="preserve">
+    <value>разбойник</value>
+  </data>
+  <data name="tagCClass34" xml:space="preserve">
+    <value>Чернокнижник</value>
+  </data>
+  <data name="tagCClass35" xml:space="preserve">
+    <value>иллюзионист</value>
+  </data>
+  <data name="tagCClass36" xml:space="preserve">
+    <value>предсказатель</value>
+  </data>
+  <data name="xtagCharacterClass01" xml:space="preserve">
+    <value>провидец</value>
+  </data>
+  <data name="xtagCharacterClass02" xml:space="preserve">
+    <value>предвестник</value>
+  </data>
+  <data name="xtagCharacterClass03" xml:space="preserve">
+    <value>тамплиер</value>
+  </data>
+  <data name="xtagCharacterClass04" xml:space="preserve">
+    <value>пробудителя</value>
+  </data>
+  <data name="xtagCharacterClass05" xml:space="preserve">
+    <value>пророк</value>
+  </data>
+  <data name="xtagCharacterClass06" xml:space="preserve">
+    <value>гаруспика</value>
+  </data>
+  <data name="xtagCharacterClass07" xml:space="preserve">
+    <value>Dreamkiller</value>
+  </data>
+  <data name="xtagCharacterClass08" xml:space="preserve">
+    <value>приверженец обрядности</value>
+  </data>
+  <data name="xtagCharacterClass09" xml:space="preserve">
+    <value>предсказатель</value>
+  </data>
+  <data name="x2tag_class_rm_rm" xml:space="preserve">
+    <value>mрун</value>
+  </data>
+  <data name="x2tag_class_warfare_rm" xml:space="preserve">
+    <value>берсерк</value>
+  </data>
+  <data name="x2tag_class_defense_rm" xml:space="preserve">
+    <value>Runesmith</value>
+  </data>
+  <data name="x2tag_class_earth_rm" xml:space="preserve">
+    <value>Stonespeaker</value>
+  </data>
+  <data name="x2tag_class_storm_rm" xml:space="preserve">
+    <value>Thгромовержец</value>
+  </data>
+  <data name="x2tag_class_hunting_rm" xml:space="preserve">
+    <value>Охотник на драконов</value>
+  </data>
+  <data name="x2tag_class_stealth_rm" xml:space="preserve">
+    <value>обманщик</value>
+  </data>
+  <data name="x2tag_class_nature_rm" xml:space="preserve">
+    <value>Skinchanger</value>
+  </data>
+  <data name="x2tag_class_spirit_rm" xml:space="preserve">
+    <value>шаман</value>
+  </data>
+  <data name="x2tag_class_dream_rm" xml:space="preserve">
+    <value>Seidr Worker</value>
+  </data>
+  <data name="CurrentLevel" xml:space="preserve">
+    <value>уровень</value>
+  </data>
+  <data name="Class" xml:space="preserve">
+    <value>Учебный класс</value>
+  </data>
+  <data name="CurrentXP" xml:space="preserve">
+    <value>XP</value>
+  </data>
+  <data name="DifficultyUnlocked" xml:space="preserve">
+    <value>трудность</value>
+  </data>
+  <data name="Money" xml:space="preserve">
+    <value>Деньги</value>
+  </data>
+  <data name="SkillPoints" xml:space="preserve">
+    <value>Очки навыка</value>
+  </data>
+  <data name="AttributesPoints" xml:space="preserve">
+    <value>Атрибуты</value>
+  </data>
+  <data name="BaseStrength" xml:space="preserve">
+    <value>База ул</value>
+  </data>
+  <data name="BaseDexterity" xml:space="preserve">
+    <value>Base Dex</value>
+  </data>
+  <data name="BaseIntelligence" xml:space="preserve">
+    <value>Base Int</value>
+  </data>
+  <data name="BaseHealth" xml:space="preserve">
+    <value>Базовое здоровье</value>
+  </data>
+  <data name="BaseMana" xml:space="preserve">
+    <value>Базовая мана</value>
+  </data>
+  <data name="PlayTimeInSeconds" xml:space="preserve">
+    <value>Время в игре</value>
+  </data>
+  <data name="NumberOfDeaths" xml:space="preserve">
+    <value>Смертей</value>
+  </data>
+  <data name="NumberOfKills" xml:space="preserve">
+    <value>Убийства</value>
+  </data>
+  <data name="ExperienceFromKills" xml:space="preserve">
+    <value>XP от убийств</value>
+  </data>
+  <data name="HealthPotionsUsed" xml:space="preserve">
+    <value>Зелья здоровья</value>
+  </data>
+  <data name="ManaPotionsUsed" xml:space="preserve">
+    <value>Кастрюли маны</value>
+  </data>
+  <data name="MaxLevel" xml:space="preserve">
+    <value>Максимальный уровень</value>
+  </data>
+  <data name="NumHitsReceived" xml:space="preserve">
+    <value>Хиты Recv</value>
+  </data>
+  <data name="NumHitsInflicted" xml:space="preserve">
+    <value>Хиты нанесены</value>
+  </data>
+  <data name="GreatestDamageInflicted" xml:space="preserve">
+    <value>Величайший урон</value>
+  </data>
+  <data name="GreatestMonster" xml:space="preserve">
+    <value>Величайшая Моб</value>
+  </data>
+  <data name="CriticalHitsInflicted" xml:space="preserve">
+    <value>Критические Хиты</value>
+  </data>
+  <data name="CriticalHitsReceived" xml:space="preserve">
+    <value>Критики приняты</value>
+  </data>
 </root>


### PR DESCRIPTION
- Disallow TQVault from creating "impossible" characters
  - Force the old "enable redistribute" mode
  - Disable manually adding skill and attribute points (more can still be added by levelling up)
- Have character edition obey the "allow cheats" flag in config 
- Rename "ShowEditingCopyFeatures" to "AllowCheats"