### PR TITLE
Make TQDebug.DebugEnabled available for Release build

### DIFF
--- a/src/TQVaultAE.Config/TQDebug.cs
+++ b/src/TQVaultAE.Config/TQDebug.cs
@@ -19,6 +19,11 @@ namespace TQVaultAE.Config
 		private static bool debugEnabled = Config.Settings.Default.DebugEnabled;
 
 		/// <summary>
+		/// Current debug level
+		/// </summary>
+		private static Level debugEnabledLevel = Level.Info;
+
+		/// <summary>
 		/// Holds the arc file debug level.
 		/// </summary>
 		private static int arcFileDebugLevel = Config.Settings.Default.ARCFileDebugLevel;
@@ -39,19 +44,30 @@ namespace TQVaultAE.Config
 		private static int itemAttributesDebugLevel = Config.Settings.Default.ItemAttributesDebugLevel;
 
 		/// <summary>
+		/// Ctor
+		/// </summary>
+		static TQDebug()
+		{
+			// Apply config at startup
+			if (debugEnabled && debugEnabledLevel != Level.Debug)
+				debugEnabledLevel = Level.Debug;
+
+			Logger.ChangeRootLogLevel(debugEnabledLevel);
+		}
+
+		/// <summary>
 		/// Gets or sets a value indicating whether debugging has been enabled
 		/// </summary>
 		public static bool DebugEnabled
 		{
-			get
-			{
-				return debugEnabled;
-			}
+			get => debugEnabled;
 			set
 			{
 				bool lastValue = debugEnabled;
 				debugEnabled = value;
-				Logger.ChangeRootLogLevel(value ? Level.Debug : Level.Info);
+
+				if (lastValue != debugEnabled)
+					Logger.ChangeRootLogLevel(value ? Level.Debug : Level.Info);
 			}
 		}
 
@@ -60,22 +76,8 @@ namespace TQVaultAE.Config
 		/// </summary>
 		public static int DatabaseDebugLevel
 		{
-			get
-			{
-				if (DebugEnabled)
-				{
-					return databaseDebugLevel;
-				}
-				else
-				{
-					return 0;
-				}
-			}
-
-			set
-			{
-				databaseDebugLevel = value;
-			}
+			get => DebugEnabled ? databaseDebugLevel : 0;
+			set => databaseDebugLevel = value;
 		}
 
 		/// <summary>
@@ -83,22 +85,8 @@ namespace TQVaultAE.Config
 		/// </summary>
 		public static int ArcFileDebugLevel
 		{
-			get
-			{
-				if (DebugEnabled)
-				{
-					return arcFileDebugLevel;
-				}
-				else
-				{
-					return 0;
-				}
-			}
-
-			set
-			{
-				arcFileDebugLevel = value;
-			}
+			get => DebugEnabled ? arcFileDebugLevel : 0;
+			set => arcFileDebugLevel = value;
 		}
 
 		/// <summary>
@@ -106,22 +94,8 @@ namespace TQVaultAE.Config
 		/// </summary>
 		public static int ItemDebugLevel
 		{
-			get
-			{
-				if (DebugEnabled)
-				{
-					return itemDebugLevel;
-				}
-				else
-				{
-					return 0;
-				}
-			}
-
-			set
-			{
-				itemDebugLevel = value;
-			}
+			get => DebugEnabled ? itemDebugLevel : 0;
+			set => itemDebugLevel = value;
 		}
 
 		/// <summary>
@@ -129,22 +103,8 @@ namespace TQVaultAE.Config
 		/// </summary>
 		public static int ItemAttributesDebugLevel
 		{
-			get
-			{
-				if (DebugEnabled)
-				{
-					return itemAttributesDebugLevel;
-				}
-				else
-				{
-					return 0;
-				}
-			}
-
-			set
-			{
-				itemAttributesDebugLevel = value;
-			}
+			get => DebugEnabled ? itemAttributesDebugLevel : 0;
+			set => itemAttributesDebugLevel = value;
 		}
 
 	}

--- a/src/TQVaultAE.GUI/Program.cs
+++ b/src/TQVaultAE.GUI/Program.cs
@@ -15,6 +15,7 @@ namespace TQVaultAE.GUI
 	using System.Security.Permissions;
 	using System.Threading;
 	using System.Windows.Forms;
+	using TQVaultAE.Config;
 	using TQVaultAE.Data;
 	using TQVaultAE.Domain.Contracts.Providers;
 	using TQVaultAE.Domain.Contracts.Services;
@@ -61,6 +62,7 @@ namespace TQVaultAE.GUI
 
 #if DEBUG
 				Logger.ChangeRootLogLevel(Level.Debug);
+				//TQDebug.DebugEnabled = true;
 #endif
 
 				// Configure DI

--- a/src/TQVaultAE.GUI/app.config
+++ b/src/TQVaultAE.GUI/app.config
@@ -90,19 +90,19 @@
   <applicationSettings>
     <TQVaultAE.Config.Settings>
       <setting name="DebugEnabled" serializeAs="String">
-        <value>True</value>
+        <value>False</value>
       </setting>
       <setting name="ARCFileDebugLevel" serializeAs="String">
-        <value>0</value>
+        <value>3</value>
       </setting>
       <setting name="DatabaseDebugLevel" serializeAs="String">
-        <value>0</value>
+        <value>3</value>
       </setting>
       <setting name="ItemDebugLevel" serializeAs="String">
-        <value>0</value>
+        <value>3</value>
       </setting>
       <setting name="ItemAttributesDebugLevel" serializeAs="String">
-        <value>0</value>
+        <value>3</value>
       </setting>
       <setting name="GameLanguages" serializeAs="String">
         <value>de,en,es,fr,it,pl,ru,cs</value>


### PR DESCRIPTION
Fix #252.
Default config value `TQDebug.DebugEnabled = False`.

**Warning : setting it to true with all level to 3 make the tool extremely slow  at startup. You may need to work on small datasets**