### PR TITLE
Fix exception for #297

### DIFF
--- a/src/TQVaultAE.GUI/MainForm.Panel.cs
+++ b/src/TQVaultAE.GUI/MainForm.Panel.cs
@@ -350,7 +350,7 @@ namespace TQVaultAE.GUI
 				else
 				{
 					// The stash is not involved.
-					if (destinationPlayerPanel.Player == null)
+					if (destinationPlayerPanel ==  null || destinationPlayerPanel.Player == null)
 					{
 						// We have nowhere to send the item so cancel the move.
 						this.DragInfo.Cancel();


### PR DESCRIPTION
Fixes the exception described in #297 and adds additional check for destinationPlayerPanel being null during an automove.