### PR TITLE
  Changes to keypress handling for #297 and #298

### DIFF
--- a/src/TQVaultAE.GUI/Components/SackPanel.cs
+++ b/src/TQVaultAE.GUI/Components/SackPanel.cs
@@ -2769,7 +2769,7 @@ namespace TQVaultAE.GUI.Components
 						// Set DragInfo to focused item.
 						this.DragInfo.Set(this, this.Sack, focusedItem, new Point(1, 1));
 
-						// copy the item
+						// duplicate the item
 						Item newItem = focusedItem.Duplicate(true);
 
 						// now drag it

--- a/src/TQVaultAE.GUI/Components/SackPanel.cs
+++ b/src/TQVaultAE.GUI/Components/SackPanel.cs
@@ -2728,7 +2728,7 @@ namespace TQVaultAE.GUI.Components
 					this.Refresh();
 					e.Handled = true;
 				}
-				else if (e.KeyChar == 'c')
+				else if (e.KeyChar == 'c' && Config.Settings.Default.AllowItemCopy == true)
 				{
 					// Copy
 					Item focusedItem = this.FindItem(this.LastCellWithFocus);
@@ -2759,18 +2759,23 @@ namespace TQVaultAE.GUI.Components
 						e.Handled = true;
 					}
 				}
-				else if (e.KeyChar == 'd')
+				else if (e.KeyChar == 'd' && Config.Settings.Default.AllowItemCopy == true)
 				{
-					// Drop (move to trash)
-					if (!this.DragInfo.IsActive)
+					// Duplicate
+					Item focusedItem = this.FindItem(this.LastCellWithFocus);
+
+					if (focusedItem != null)
 					{
-						Item focusedItem = this.FindItem(this.LastCellWithFocus);
-						if (focusedItem != null)
-						{
-							this.DragInfo.Set(this, this.Sack, focusedItem, new Point(1, 1));
-							this.DragInfo.AutoMove = AutoMoveLocation.Trash;
-							this.OnAutoMoveItem(this, new SackPanelEventArgs(null, null));
-						}
+						// Set DragInfo to focused item.
+						this.DragInfo.Set(this, this.Sack, focusedItem, new Point(1, 1));
+
+						// copy the item
+						Item newItem = focusedItem.Duplicate(true);
+
+						// now drag it
+						this.DragInfo.MarkModified(newItem);
+						this.Refresh();
+						e.Handled = true;
 					}
 				}
 


### PR DESCRIPTION
Adds check for allow item copy for the copy hotkey for #298 
Changes functionality of d hotkey to duplicate an item for #297 since dropping an item is no longer applicable without a trash panel.