### PR TITLE
Hotkey to select all highlighted items in the current panel

### DIFF
--- a/src/TQVaultAE.GUI/Components/SackPanel.cs
+++ b/src/TQVaultAE.GUI/Components/SackPanel.cs
@@ -723,6 +723,25 @@ public class SackPanel : Panel, IScalingControl
 	}
 
 	/// <summary>
+	/// Selects all highlighted items in the sack
+	/// </summary>
+	public void SelectAllHighlightedItems()
+	{
+		if (this.Sack != null && !this.Sack.IsEmpty)
+		{
+			if (this.selectedItems != null)
+				this.ClearSelection();
+
+			foreach (Item item in this.userContext.HighlightedItems)
+			{
+				if (this.Sack.Contains(item))
+					this.SelectItem(item);
+			}
+			this.Invalidate();
+		}
+	}
+
+	/// <summary>
 	/// Merges the items from two sacks into one sack
 	/// </summary>
 	/// <param name="destination">sack number where we are storing the combined sack</param>
@@ -3557,6 +3576,9 @@ public class SackPanel : Panel, IScalingControl
 
 		if (e.KeyData == (Keys.Control | Keys.A))
 			this.SelectAllItems();
+
+		if (e.KeyData == (Keys.Control | Keys.S))
+			this.SelectAllHighlightedItems();
 
 		if (e.KeyData == (Keys.Control | Keys.D))
 			this.OnClearAllItemsSelected(this, new SackPanelEventArgs(null, null));


### PR DESCRIPTION
Ctrl+S will select all highlighted items in the current sack.

![selectHighlighted pre](https://user-images.githubusercontent.com/19972862/234947568-02fdc70c-1e81-4e29-97a4-3bffa14e7f4d.png)
->
![selectHighlighted post](https://user-images.githubusercontent.com/19972862/234947612-2cf98507-94fd-4866-add9-80bc22aedb0f.png)

(the transfer to another vault is only for effect, not part of the functionality)